### PR TITLE
use `sipper` to fetch trades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,7 +1258,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -1519,12 +1518,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
@@ -1689,11 +1682,12 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=4b075b9731f4658a885357024cc77dee10e223c3#4b075b9731f4658a885357024cc77dee10e223c3"
+source = "git+https://github.com/iced-rs/iced?rev=cd27dae8abdecc5ff751e1e201ade79bc6b8e23a#cd27dae8abdecc5ff751e1e201ade79bc6b8e23a"
 dependencies = [
  "iced_core 0.14.0-dev",
  "iced_futures 0.14.0-dev",
  "iced_renderer",
+ "iced_runtime",
  "iced_widget",
  "iced_winit",
  "thiserror 1.0.69",
@@ -1721,7 +1715,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=4b075b9731f4658a885357024cc77dee10e223c3#4b075b9731f4658a885357024cc77dee10e223c3"
+source = "git+https://github.com/iced-rs/iced?rev=cd27dae8abdecc5ff751e1e201ade79bc6b8e23a#cd27dae8abdecc5ff751e1e201ade79bc6b8e23a"
 dependencies = [
  "bitflags 2.8.0",
  "bytes",
@@ -1729,7 +1723,6 @@ dependencies = [
  "lilt",
  "log",
  "num-traits",
- "palette",
  "rustc-hash 2.1.1",
  "smol_str",
  "thiserror 1.0.69",
@@ -1753,7 +1746,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=4b075b9731f4658a885357024cc77dee10e223c3#4b075b9731f4658a885357024cc77dee10e223c3"
+source = "git+https://github.com/iced-rs/iced?rev=cd27dae8abdecc5ff751e1e201ade79bc6b8e23a#cd27dae8abdecc5ff751e1e201ade79bc6b8e23a"
 dependencies = [
  "futures",
  "iced_core 0.14.0-dev",
@@ -1767,7 +1760,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=4b075b9731f4658a885357024cc77dee10e223c3#4b075b9731f4658a885357024cc77dee10e223c3"
+source = "git+https://github.com/iced-rs/iced?rev=cd27dae8abdecc5ff751e1e201ade79bc6b8e23a#cd27dae8abdecc5ff751e1e201ade79bc6b8e23a"
 dependencies = [
  "bitflags 2.8.0",
  "bytemuck",
@@ -1786,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=4b075b9731f4658a885357024cc77dee10e223c3#4b075b9731f4658a885357024cc77dee10e223c3"
+source = "git+https://github.com/iced-rs/iced?rev=cd27dae8abdecc5ff751e1e201ade79bc6b8e23a#cd27dae8abdecc5ff751e1e201ade79bc6b8e23a"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -1798,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=4b075b9731f4658a885357024cc77dee10e223c3#4b075b9731f4658a885357024cc77dee10e223c3"
+source = "git+https://github.com/iced-rs/iced?rev=cd27dae8abdecc5ff751e1e201ade79bc6b8e23a#cd27dae8abdecc5ff751e1e201ade79bc6b8e23a"
 dependencies = [
  "bytes",
  "iced_core 0.14.0-dev",
@@ -1811,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=4b075b9731f4658a885357024cc77dee10e223c3#4b075b9731f4658a885357024cc77dee10e223c3"
+source = "git+https://github.com/iced-rs/iced?rev=cd27dae8abdecc5ff751e1e201ade79bc6b8e23a#cd27dae8abdecc5ff751e1e201ade79bc6b8e23a"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -1826,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=4b075b9731f4658a885357024cc77dee10e223c3#4b075b9731f4658a885357024cc77dee10e223c3"
+source = "git+https://github.com/iced-rs/iced?rev=cd27dae8abdecc5ff751e1e201ade79bc6b8e23a#cd27dae8abdecc5ff751e1e201ade79bc6b8e23a"
 dependencies = [
  "bitflags 2.8.0",
  "bytemuck",
@@ -1845,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=4b075b9731f4658a885357024cc77dee10e223c3#4b075b9731f4658a885357024cc77dee10e223c3"
+source = "git+https://github.com/iced-rs/iced?rev=cd27dae8abdecc5ff751e1e201ade79bc6b8e23a#cd27dae8abdecc5ff751e1e201ade79bc6b8e23a"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -1860,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced?rev=4b075b9731f4658a885357024cc77dee10e223c3#4b075b9731f4658a885357024cc77dee10e223c3"
+source = "git+https://github.com/iced-rs/iced?rev=cd27dae8abdecc5ff751e1e201ade79bc6b8e23a#cd27dae8abdecc5ff751e1e201ade79bc6b8e23a"
 dependencies = [
  "iced_futures 0.14.0-dev",
  "iced_graphics",
@@ -2470,16 +2463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
 name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,7 +3009,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "pin-project-lite",
  "rustix",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ iced = { version = "0.14.0-dev", default-features = false, features = [
     "lazy", 
     "tokio", 
     "canvas",
+    "sipper",
     "advanced",
     "unconditional-rendering",
 ] }
@@ -47,6 +48,6 @@ exchange = { version = "0.1.0", path = "exchange" }
 data = { version = "0.1.0", path = "data" }
 
 [patch.crates-io]
-iced = { git = "https://github.com/iced-rs/iced", rev = "4b075b9731f4658a885357024cc77dee10e223c3" }
-iced_core = { git = "https://github.com/iced-rs/iced", rev = "4b075b9731f4658a885357024cc77dee10e223c3", package = "iced_core" }
+iced = { git = "https://github.com/iced-rs/iced", rev = "cd27dae8abdecc5ff751e1e201ade79bc6b8e23a" }
+iced_core = { git = "https://github.com/iced-rs/iced", rev = "cd27dae8abdecc5ff751e1e201ade79bc6b8e23a", package = "iced_core" }
 

--- a/src/charts/footprint.rs
+++ b/src/charts/footprint.rs
@@ -324,7 +324,10 @@ impl FootprintChart {
 
                         let request = request_fetch(
                             &mut self.request_handler,
-                            FetchRange::Trades(last_kline_before_gap, first_kline_after_gap),
+                            FetchRange::Trades(
+                                last_kline_before_gap.max(visible_earliest),
+                                first_kline_after_gap.min(visible_latest),
+                            ),
                         );
 
                         if !matches!(request, Action::None) {

--- a/src/charts/footprint.rs
+++ b/src/charts/footprint.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use data::UserTimezone;
 use data::chart::ChartLayout;
 use data::chart::indicators::{FootprintIndicator, Indicator};
+use iced::task::Handle;
 use iced::theme::palette::Extended;
 use iced::widget::canvas::{LineDash, Path, Stroke};
 use iced::widget::container;
@@ -133,7 +134,7 @@ pub struct FootprintChart {
     data_source: ChartData,
     raw_trades: Vec<Trade>,
     indicators: HashMap<FootprintIndicator, IndicatorData>,
-    fetching_trades: bool,
+    fetching_trades: (bool, Option<Handle>),
     request_handler: RequestHandler,
 }
 
@@ -197,7 +198,7 @@ impl FootprintChart {
                             })
                             .collect()
                     },
-                    fetching_trades: false,
+                    fetching_trades: (false, None),
                     request_handler: RequestHandler::new(),
                 }
             }
@@ -245,7 +246,7 @@ impl FootprintChart {
                             })
                             .collect()
                     },
-                    fetching_trades: false,
+                    fetching_trades: (false, None),
                     request_handler: RequestHandler::new(),
                 }
             }
@@ -299,7 +300,7 @@ impl FootprintChart {
                     );
                 }
 
-                if !self.fetching_trades {
+                if !self.fetching_trades.0 {
                     if let Some(earliest_gap) = timeseries
                         .data_points
                         .range(visible_earliest..=visible_latest)
@@ -327,7 +328,7 @@ impl FootprintChart {
                         );
 
                         if !matches!(request, Action::None) {
-                            self.fetching_trades = true;
+                            self.fetching_trades = (true, None);
                             return request;
                         }
                     }
@@ -382,7 +383,7 @@ impl FootprintChart {
 
     pub fn reset_request_handler(&mut self) {
         self.request_handler = RequestHandler::new();
-        self.fetching_trades = false;
+        self.fetching_trades = (false, None);
     }
 
     pub fn get_raw_trades(&self) -> Vec<Trade> {
@@ -404,6 +405,10 @@ impl FootprintChart {
                 // TODO: implement
             }
         }
+    }
+
+    pub fn set_handle(&mut self, handle: Handle) {
+        self.fetching_trades.1 = Some(handle);
     }
 
     pub fn get_tick_size(&self) -> f32 {
@@ -508,7 +513,7 @@ impl FootprintChart {
         self.raw_trades.extend(raw_trades);
 
         if is_batches_done {
-            self.fetching_trades = false;
+            self.fetching_trades = (false, None);
         }
     }
 

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -554,7 +554,7 @@ impl Dashboard {
                             let data_path = data::get_data_path("market_data/binance/");
                             let dashboard_id = *layout_id;
 
-                            let (task, _) = Task::sip(
+                            let (task, handle) = Task::sip(
                                 fetch_trades_batched(ticker, from_time, to_time, data_path),
                                 move |batch| {
                                     let data = FetchedData::Trades(batch, to_time);
@@ -576,6 +576,12 @@ impl Dashboard {
                                 },
                             )
                             .abortable();
+
+                            if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
+                                if let PaneContent::Footprint(chart, _) = &mut state.content {
+                                    chart.set_handle(handle.abort_on_drop());
+                                }
+                            };
 
                             return (task, None);
                         }


### PR DESCRIPTION
This PR aims to streamline trade fetch requests by using `Task::sip`, so that we can send fetched batches(`Vec<Trade>`) to charts conciser. Before, this was done by chaining `Message`s and relying on another `Task` for each next batch. Now because of a single `Task`, it will also make these requests easily abortable