### PR TITLE
Improved autoscaling for `KlineChart`

### DIFF
--- a/data/src/aggr/ticks.rs
+++ b/data/src/aggr/ticks.rs
@@ -201,6 +201,31 @@ impl TickAggr {
         }
     }
 
+    pub fn min_max_price_in_range(
+        &self,
+        earliest: usize,
+        latest: usize,
+    ) -> Option<(OrderedFloat<f32>, OrderedFloat<f32>)> {
+        let mut min_price = OrderedFloat(f32::MAX);
+        let mut max_price = OrderedFloat(f32::MIN);
+
+        self.datapoints
+            .iter()
+            .rev()
+            .enumerate()
+            .filter(|(index, _)| *index <= latest && *index >= earliest)
+            .for_each(|(_, dp)| {
+                min_price = min_price.min(OrderedFloat(dp.kline.low));
+                max_price = max_price.max(OrderedFloat(dp.kline.high));
+            });
+
+        if min_price.0 == f32::MAX || max_price.0 == f32::MIN {
+            None
+        } else {
+            Some((min_price, max_price))
+        }
+    }
+
     pub fn max_qty_idx_range(
         &self,
         cluster_kind: ClusterKind,

--- a/data/src/aggr/ticks.rs
+++ b/data/src/aggr/ticks.rs
@@ -201,11 +201,7 @@ impl TickAggr {
         }
     }
 
-    pub fn min_max_price_in_range(
-        &self,
-        earliest: usize,
-        latest: usize,
-    ) -> Option<(OrderedFloat<f32>, OrderedFloat<f32>)> {
+    pub fn min_max_price_in_range(&self, earliest: usize, latest: usize) -> Option<(f32, f32)> {
         let mut min_price = OrderedFloat(f32::MAX);
         let mut max_price = OrderedFloat(f32::MIN);
 
@@ -222,7 +218,7 @@ impl TickAggr {
         if min_price.0 == f32::MAX || max_price.0 == f32::MIN {
             None
         } else {
-            Some((min_price, max_price))
+            Some((*min_price, *max_price))
         }
     }
 

--- a/data/src/aggr/time.rs
+++ b/data/src/aggr/time.rs
@@ -256,12 +256,10 @@ impl TimeSeries {
                 let (kline_earliest, kline_latest) = self.kline_timerange();
 
                 let fetch_from = last_t_before_gap
-                    .map(|t| t.saturating_add(1))
-                    .unwrap_or(kline_earliest)
+                    .map_or(kline_earliest, |t| t.saturating_add(1))
                     .max(visible_earliest);
                 let fetch_to = first_t_after_gap
-                    .map(|t| t.saturating_sub(1))
-                    .unwrap_or(kline_latest)
+                    .map_or(kline_latest, |t| t.saturating_sub(1))
                     .min(visible_latest);
 
                 if fetch_from < fetch_to {

--- a/data/src/aggr/time.rs
+++ b/data/src/aggr/time.rs
@@ -153,11 +153,7 @@ impl TimeSeries {
         self.update_poc_status();
     }
 
-    pub fn min_max_price_in_range(
-        &self,
-        earliest: u64,
-        latest: u64,
-    ) -> Option<(OrderedFloat<f32>, OrderedFloat<f32>)> {
+    pub fn min_max_price_in_range(&self, earliest: u64, latest: u64) -> Option<(f32, f32)> {
         let mut min_price = OrderedFloat(f32::MAX);
         let mut max_price = OrderedFloat(f32::MIN);
 
@@ -169,7 +165,7 @@ impl TimeSeries {
         if min_price.0 == f32::MAX || max_price.0 == f32::MIN {
             None
         } else {
-            Some((min_price, max_price))
+            Some((*min_price, *max_price))
         }
     }
 

--- a/data/src/aggr/time.rs
+++ b/data/src/aggr/time.rs
@@ -153,6 +153,26 @@ impl TimeSeries {
         self.update_poc_status();
     }
 
+    pub fn min_max_price_in_range(
+        &self,
+        earliest: u64,
+        latest: u64,
+    ) -> Option<(OrderedFloat<f32>, OrderedFloat<f32>)> {
+        let mut min_price = OrderedFloat(f32::MAX);
+        let mut max_price = OrderedFloat(f32::MIN);
+
+        for (_, data_point) in self.datapoints.range(earliest..=latest) {
+            min_price = min_price.min(OrderedFloat(data_point.kline.low));
+            max_price = max_price.max(OrderedFloat(data_point.kline.high));
+        }
+
+        if min_price.0 == f32::MAX || max_price.0 == f32::MIN {
+            None
+        } else {
+            Some((min_price, max_price))
+        }
+    }
+
     pub fn insert_trades(&mut self, buffer: &[Trade]) {
         if buffer.is_empty() {
             return;

--- a/data/src/chart.rs
+++ b/data/src/chart.rs
@@ -25,10 +25,16 @@ pub enum Autoscale {
 }
 
 impl Autoscale {
-    pub fn next(current: Option<Autoscale>) -> Option<Autoscale> {
+    pub fn next(current: Option<Autoscale>, supports_fit_autoscaling: bool) -> Option<Autoscale> {
         match current {
             None => Some(Autoscale::CenterLatest),
-            Some(Autoscale::CenterLatest) => Some(Autoscale::FitToVisible),
+            Some(Autoscale::CenterLatest) => {
+                if supports_fit_autoscaling {
+                    Some(Autoscale::FitToVisible)
+                } else {
+                    None
+                }
+            }
             Some(Autoscale::FitToVisible) => None,
         }
     }

--- a/data/src/chart.rs
+++ b/data/src/chart.rs
@@ -10,10 +10,28 @@ pub use kline::KlineChartKind;
 
 use crate::aggr;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ChartLayout {
     pub crosshair: bool,
     pub splits: Vec<f32>,
+    pub autoscale: Option<Autoscale>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Default, PartialEq)]
+pub enum Autoscale {
+    #[default]
+    CenterLatest,
+    FitToVisible,
+}
+
+impl Autoscale {
+    pub fn next(current: Option<Autoscale>) -> Option<Autoscale> {
+        match current {
+            None => Some(Autoscale::CenterLatest),
+            Some(Autoscale::CenterLatest) => Some(Autoscale::FitToVisible),
+            Some(Autoscale::FitToVisible) => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]

--- a/data/src/chart.rs
+++ b/data/src/chart.rs
@@ -1,14 +1,57 @@
-use exchange::{Timeframe, adapter::Exchange};
-use serde::{Deserialize, Serialize};
-
 pub mod heatmap;
 pub mod indicator;
 pub mod kline;
 pub mod timeandsales;
 
+use super::aggr::{self, ticks::TickAggr, time::TimeSeries};
+use exchange::{Timeframe, adapter::Exchange};
+use ordered_float::OrderedFloat;
+use serde::{Deserialize, Serialize};
+
 pub use kline::KlineChartKind;
 
-use crate::aggr;
+pub enum ChartData {
+    TimeBased(TimeSeries),
+    TickBased(TickAggr),
+}
+
+impl ChartData {
+    pub fn latest_y_midpoint(&self, calculate_target_y: impl Fn(exchange::Kline) -> f32) -> f32 {
+        match self {
+            ChartData::TimeBased(timeseries) => timeseries
+                .latest_kline()
+                .map_or(0.0, |kline| calculate_target_y(*kline)),
+            ChartData::TickBased(tick_aggr) => tick_aggr
+                .latest_dp()
+                .map_or(0.0, |(dp, _)| calculate_target_y(dp.kline)),
+        }
+    }
+
+    pub fn visible_price_range(
+        &self,
+        start_interval: u64,
+        end_interval: u64,
+    ) -> Option<(OrderedFloat<f32>, OrderedFloat<f32>)> {
+        match self {
+            ChartData::TimeBased(timeseries) => {
+                timeseries.min_max_price_in_range(start_interval, end_interval)
+            }
+            ChartData::TickBased(tick_aggr) => {
+                tick_aggr.min_max_price_in_range(start_interval as usize, end_interval as usize)
+            }
+        }
+    }
+}
+
+pub trait ChartConstants {
+    fn min_scaling(&self) -> f32;
+    fn max_scaling(&self) -> f32;
+    fn max_cell_width(&self) -> f32;
+    fn min_cell_width(&self) -> f32;
+    fn max_cell_height(&self) -> f32;
+    fn min_cell_height(&self) -> f32;
+    fn default_cell_width(&self) -> f32;
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ChartLayout {

--- a/data/src/chart.rs
+++ b/data/src/chart.rs
@@ -5,7 +5,6 @@ pub mod timeandsales;
 
 use super::aggr::{self, ticks::TickAggr, time::TimeSeries};
 use exchange::{Timeframe, adapter::Exchange};
-use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 
 pub use kline::KlineChartKind;
@@ -31,7 +30,7 @@ impl PlotData {
         &self,
         start_interval: u64,
         end_interval: u64,
-    ) -> Option<(OrderedFloat<f32>, OrderedFloat<f32>)> {
+    ) -> Option<(f32, f32)> {
         match self {
             PlotData::TimeBased(timeseries) => {
                 timeseries.min_max_price_in_range(start_interval, end_interval)

--- a/data/src/chart/heatmap.rs
+++ b/data/src/chart/heatmap.rs
@@ -298,12 +298,12 @@ impl HistoricalDepth {
         let query_lowest_price = price_tick_offsets
             .iter()
             .map(|offset| center_price + (*offset as f32 * tick_size))
-            .fold(f32::INFINITY, |a, b| a.min(b))
+            .fold(f32::INFINITY, f32::min)
             - 0.1 * tick_size;
         let query_highest_price = price_tick_offsets
             .iter()
             .map(|offset| center_price + (*offset as f32 * tick_size))
-            .fold(f32::NEG_INFINITY, |a, b| a.max(b))
+            .fold(f32::NEG_INFINITY, f32::max)
             + 0.1 * tick_size;
 
         let runs_in_vicinity = if let Some(ck) = coalesce_kind {

--- a/data/src/layout/pane.rs
+++ b/data/src/layout/pane.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
 use crate::chart::{
-    Basis, ChartLayout, VisualConfig,
+    Basis, ViewConfig, VisualConfig,
     indicator::{HeatmapIndicator, KlineIndicator},
     kline::KlineChartKind,
 };
@@ -25,7 +25,7 @@ pub enum Pane {
     #[default]
     Starter,
     HeatmapChart {
-        layout: ChartLayout,
+        layout: ViewConfig,
         #[serde(deserialize_with = "ok_or_default")]
         stream_type: Vec<StreamKind>,
         #[serde(deserialize_with = "ok_or_default")]
@@ -33,7 +33,7 @@ pub enum Pane {
         indicators: Vec<HeatmapIndicator>,
     },
     KlineChart {
-        layout: ChartLayout,
+        layout: ViewConfig,
         kind: KlineChartKind,
         #[serde(deserialize_with = "ok_or_default")]
         stream_type: Vec<StreamKind>,

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -298,6 +298,7 @@ pub fn update<T: Chart>(chart: &mut T, message: Message) {
                 AxisScaleClicked::Y => {
                     if supports_fit_autoscaling {
                         chart_state.layout.autoscale = Some(Autoscale::FitToVisible);
+                        chart_state.scaling = 1.0;
                     } else {
                         chart_state.layout.autoscale = Some(Autoscale::CenterLatest);
                     }

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -518,8 +518,8 @@ pub fn view<'a, T: Chart>(
     let chart_controls = {
         let (autoscale_btn_placeholder, autoscale_btn_tooltip) = match chart_state.layout.autoscale
         {
-            Some(Autoscale::CenterLatest) => (text("C"), Some("Center latest")),
-            Some(Autoscale::FitToVisible) => (text("A"), Some("Fit to visible")),
+            Some(Autoscale::CenterLatest) => (text("C"), Some("Center last price")),
+            Some(Autoscale::FitToVisible) => (text("A"), Some("Auto")),
             None => (text("C"), None),
         };
 

--- a/src/chart/heatmap.rs
+++ b/src/chart/heatmap.rs
@@ -31,11 +31,11 @@ const TOOLTIP_PADDING: f32 = 12.0;
 impl Chart for HeatmapChart {
     type IndicatorType = HeatmapIndicator;
 
-    fn common_data(&self) -> &ViewState {
+    fn state(&self) -> &ViewState {
         &self.chart
     }
 
-    fn common_data_mut(&mut self) -> &mut ViewState {
+    fn mut_state(&mut self) -> &mut ViewState {
         &mut self.chart
     }
 
@@ -48,7 +48,7 @@ impl Chart for HeatmapChart {
     }
 
     fn visible_timerange(&self) -> (u64, u64) {
-        let chart = self.common_data();
+        let chart = self.state();
         let visible_region = chart.visible_region(chart.bounds.size());
 
         (
@@ -62,7 +62,7 @@ impl Chart for HeatmapChart {
     }
 
     fn autoscaled_coords(&self) -> Vector {
-        let chart = self.common_data();
+        let chart = self.state();
         Vector::new(
             0.5 * (chart.bounds.width / chart.scaling) - (90.0 / chart.scaling),
             chart.translation.y,
@@ -362,7 +362,7 @@ impl HeatmapChart {
     }
 
     pub fn change_tick_size(&mut self, new_tick_size: f32) {
-        let chart_state = self.common_data_mut();
+        let chart_state = self.mut_state();
 
         let basis = chart_state.basis;
 
@@ -511,7 +511,7 @@ impl canvas::Program<Message> for HeatmapChart {
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> Vec<Geometry> {
-        let chart = self.common_data();
+        let chart = self.state();
 
         if chart.bounds.width == 0.0 {
             return vec![];

--- a/src/chart/heatmap.rs
+++ b/src/chart/heatmap.rs
@@ -1,9 +1,9 @@
 use super::{
-    Chart, ChartConstants, Interaction, Message, ViewState, scale::linear::PriceInfoLabel,
+    Chart, PlotConstants, Interaction, Message, ViewState, scale::linear::PriceInfoLabel,
 };
 use crate::{chart::TEXT_SIZE, style};
 use data::chart::{
-    Basis, ChartLayout,
+    Basis, ViewConfig,
     heatmap::{Config, GroupedTrade, HistoricalDepth, QtyScale},
     indicator::HeatmapIndicator,
 };
@@ -78,7 +78,7 @@ impl Chart for HeatmapChart {
     }
 }
 
-impl ChartConstants for HeatmapChart {
+impl PlotConstants for HeatmapChart {
     fn min_scaling(&self) -> f32 {
         data::chart::heatmap::MIN_SCALING
     }
@@ -125,7 +125,7 @@ pub struct HeatmapChart {
 
 impl HeatmapChart {
     pub fn new(
-        layout: ChartLayout,
+        layout: ViewConfig,
         basis: Basis,
         tick_size: f32,
         enabled_indicators: &[HeatmapIndicator],
@@ -357,7 +357,7 @@ impl HeatmapChart {
         }
     }
 
-    pub fn chart_layout(&self) -> ChartLayout {
+    pub fn chart_layout(&self) -> ViewConfig {
         self.chart.layout()
     }
 

--- a/src/chart/heatmap.rs
+++ b/src/chart/heatmap.rs
@@ -61,6 +61,18 @@ impl Chart for HeatmapChart {
         None
     }
 
+    fn autoscaled_coords(&self) -> Vector {
+        let chart = self.common_data();
+        Vector::new(
+            0.5 * (chart.bounds.width / chart.scaling) - (90.0 / chart.scaling),
+            chart.translation.y,
+        )
+    }
+
+    fn supports_fit_autoscaling(&self) -> bool {
+        false
+    }
+
     fn is_empty(&self) -> bool {
         self.timeseries.is_empty()
     }

--- a/src/chart/heatmap.rs
+++ b/src/chart/heatmap.rs
@@ -1,5 +1,5 @@
 use super::{
-    Chart, ChartConstants, CommonChartData, Interaction, Message, scale::linear::PriceInfoLabel,
+    Chart, ChartConstants, Interaction, Message, ViewState, scale::linear::PriceInfoLabel,
 };
 use crate::{chart::TEXT_SIZE, style};
 use data::chart::{
@@ -31,11 +31,11 @@ const TOOLTIP_PADDING: f32 = 12.0;
 impl Chart for HeatmapChart {
     type IndicatorType = HeatmapIndicator;
 
-    fn common_data(&self) -> &CommonChartData {
+    fn common_data(&self) -> &ViewState {
         &self.chart
     }
 
-    fn common_data_mut(&mut self) -> &mut CommonChartData {
+    fn common_data_mut(&mut self) -> &mut ViewState {
         &mut self.chart
     }
 
@@ -114,7 +114,7 @@ enum IndicatorData {
 }
 
 pub struct HeatmapChart {
-    chart: CommonChartData,
+    chart: ViewState,
     timeseries: BTreeMap<u64, (Box<[GroupedTrade]>, (f32, f32))>,
     indicators: HashMap<HeatmapIndicator, IndicatorData>,
     pause_buffer: Vec<(u64, Box<[Trade]>, Depth)>,
@@ -133,7 +133,7 @@ impl HeatmapChart {
         config: Option<Config>,
     ) -> Self {
         HeatmapChart {
-            chart: CommonChartData {
+            chart: ViewState {
                 cell_width: data::chart::heatmap::DEFAULT_CELL_WIDTH,
                 cell_height: 4.0,
                 tick_size,
@@ -358,7 +358,7 @@ impl HeatmapChart {
     }
 
     pub fn chart_layout(&self) -> ChartLayout {
-        self.chart.get_chart_layout()
+        self.chart.layout()
     }
 
     pub fn change_tick_size(&mut self, new_tick_size: f32) {

--- a/src/chart/indicator/open_interest.rs
+++ b/src/chart/indicator/open_interest.rs
@@ -4,13 +4,13 @@ use iced::widget::canvas::{self, Cache, Event, Geometry, Path, Stroke};
 use iced::widget::{Canvas, center, container, row, text, vertical_rule};
 use iced::{Element, Length, Point, Rectangle, Renderer, Size, Theme, Vector, mouse};
 
-use crate::chart::{Basis, Caches, CommonChartData, Interaction, Message};
+use crate::chart::{Basis, Caches, ViewState, Interaction, Message};
 use crate::style::{self, dashed_line};
 use data::util::{format_with_commas, guesstimate_ticks, round_to_tick};
 use exchange::Timeframe;
 
 pub fn indicator_elem<'a>(
-    chart_state: &'a CommonChartData,
+    chart_state: &'a ViewState,
     cache: &'a Caches,
     datapoints: &'a BTreeMap<u64, f32>,
     earliest: u64,
@@ -80,7 +80,7 @@ pub fn indicator_elem<'a>(
 pub struct OpenInterest<'a> {
     pub indicator_cache: &'a Cache,
     pub crosshair_cache: &'a Cache,
-    pub chart_state: &'a CommonChartData,
+    pub chart_state: &'a ViewState,
     pub max_value: f32,
     pub timeseries: &'a BTreeMap<u64, f32>,
 }

--- a/src/chart/indicator/open_interest.rs
+++ b/src/chart/indicator/open_interest.rs
@@ -63,7 +63,7 @@ pub fn indicator_elem<'a>(
         label_cache: &cache.y_labels,
         max: max_value,
         min: min_value,
-        crosshair: chart_state.crosshair,
+        crosshair: chart_state.layout.crosshair,
         chart_bounds: chart_state.bounds,
     })
     .height(Length::Fill)
@@ -113,7 +113,7 @@ impl canvas::Program<Message> for OpenInterest<'_> {
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {
                 let message = match *interaction {
                     Interaction::None => {
-                        if self.chart_state.crosshair && cursor.is_over(bounds) {
+                        if self.chart_state.layout.crosshair && cursor.is_over(bounds) {
                             Some(Message::CrosshairMoved)
                         } else {
                             None
@@ -228,7 +228,7 @@ impl canvas::Program<Message> for OpenInterest<'_> {
             }
         });
 
-        if chart_state.crosshair {
+        if chart_state.layout.crosshair {
             let crosshair = self.crosshair_cache.draw(renderer, bounds.size(), |frame| {
                 let dashed_line = dashed_line(theme);
 
@@ -344,7 +344,7 @@ impl canvas::Program<Message> for OpenInterest<'_> {
             Interaction::Panning { .. } => mouse::Interaction::Grabbing,
             Interaction::Zoomin { .. } => mouse::Interaction::ZoomIn,
             Interaction::None if cursor.is_over(bounds) => {
-                if self.chart_state.crosshair {
+                if self.chart_state.layout.crosshair {
                     mouse::Interaction::Crosshair
                 } else {
                     mouse::Interaction::default()

--- a/src/chart/indicator/volume.rs
+++ b/src/chart/indicator/volume.rs
@@ -62,7 +62,7 @@ pub fn indicator_elem<'a>(
         label_cache: &cache.y_labels,
         max: max_volume,
         min: 0.0,
-        crosshair: chart_state.crosshair,
+        crosshair: chart_state.layout.crosshair,
         chart_bounds: chart_state.bounds,
     })
     .height(Length::Fill)
@@ -112,7 +112,7 @@ impl canvas::Program<Message> for VolumeIndicator<'_> {
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {
                 let message = match *interaction {
                     Interaction::None => {
-                        if self.chart_state.crosshair && cursor.is_over(bounds) {
+                        if self.chart_state.layout.crosshair && cursor.is_over(bounds) {
                             Some(Message::CrosshairMoved)
                         } else {
                             None
@@ -264,7 +264,7 @@ impl canvas::Program<Message> for VolumeIndicator<'_> {
             }
         });
 
-        if chart_state.crosshair {
+        if chart_state.layout.crosshair {
             let crosshair = self.crosshair_cache.draw(renderer, bounds.size(), |frame| {
                 let dashed_line = dashed_line(theme);
 
@@ -430,7 +430,7 @@ impl canvas::Program<Message> for VolumeIndicator<'_> {
             Interaction::Panning { .. } => mouse::Interaction::Grabbing,
             Interaction::Zoomin { .. } => mouse::Interaction::ZoomIn,
             Interaction::None if cursor.is_over(bounds) => {
-                if self.chart_state.crosshair {
+                if self.chart_state.layout.crosshair {
                     mouse::Interaction::Crosshair
                 } else {
                     mouse::Interaction::default()

--- a/src/chart/indicator/volume.rs
+++ b/src/chart/indicator/volume.rs
@@ -5,13 +5,13 @@ use iced::widget::{Canvas, container, row, vertical_rule};
 use iced::{Element, Length};
 use iced::{Point, Rectangle, Renderer, Size, Theme, Vector, mouse};
 
-use crate::chart::{Basis, Caches, CommonChartData, Interaction, Message};
+use crate::chart::{Basis, Caches, ViewState, Interaction, Message};
 use crate::style::{self, dashed_line};
 
 use data::util::{format_with_commas, round_to_tick};
 
 pub fn indicator_elem<'a>(
-    chart_state: &'a CommonChartData,
+    chart_state: &'a ViewState,
     cache: &'a Caches,
     datapoints: &'a BTreeMap<u64, (f32, f32)>,
     earliest: u64,
@@ -81,7 +81,7 @@ pub struct VolumeIndicator<'a> {
     pub crosshair_cache: &'a Cache,
     pub max_volume: f32,
     pub datapoints: &'a BTreeMap<u64, (f32, f32)>,
-    pub chart_state: &'a CommonChartData,
+    pub chart_state: &'a ViewState,
 }
 
 impl VolumeIndicator<'_> {

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -30,11 +30,11 @@ use std::time::Instant;
 impl Chart for KlineChart {
     type IndicatorType = KlineIndicator;
 
-    fn common_data(&self) -> &ViewState {
+    fn state(&self) -> &ViewState {
         &self.chart
     }
 
-    fn common_data_mut(&mut self) -> &mut ViewState {
+    fn mut_state(&mut self) -> &mut ViewState {
         &mut self.chart
     }
 
@@ -43,7 +43,7 @@ impl Chart for KlineChart {
     }
 
     fn view_indicators(&self, enabled: &[Self::IndicatorType]) -> Vec<Element<Message>> {
-        let chart_state: &ViewState = self.common_data();
+        let chart_state = self.state();
 
         let visible_region = chart_state.visible_region(chart_state.bounds.size());
         let (earliest, latest) = chart_state.interval_range(&visible_region);
@@ -73,7 +73,7 @@ impl Chart for KlineChart {
     }
 
     fn visible_timerange(&self) -> (u64, u64) {
-        let chart = self.common_data();
+        let chart = self.state();
         let region = chart.visible_region(chart.bounds.size());
 
         match &chart.basis {
@@ -107,7 +107,7 @@ impl Chart for KlineChart {
     }
 
     fn autoscaled_coords(&self) -> Vector {
-        let chart = self.common_data();
+        let chart = self.state();
         let x_translation = match &self.kind {
             KlineChartKind::Footprint { .. } => {
                 0.5 * (chart.bounds.width / chart.scaling) - (chart.cell_width / chart.scaling)
@@ -372,7 +372,7 @@ impl KlineChart {
                     data.insert(kline.time, (kline.volume.0, kline.volume.1));
                 };
 
-                let chart = self.common_data_mut();
+                let chart = self.mut_state();
 
                 if (kline.time) > chart.latest_x {
                     chart.latest_x = kline.time;
@@ -557,7 +557,7 @@ impl KlineChart {
     }
 
     pub fn change_tick_size(&mut self, new_tick_size: f32) {
-        let chart = self.common_data_mut();
+        let chart = self.mut_state();
 
         chart.cell_height *= new_tick_size / chart.tick_size;
         chart.tick_size = new_tick_size;
@@ -884,7 +884,7 @@ impl canvas::Program<Message> for KlineChart {
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> Vec<Geometry> {
-        let chart = self.common_data();
+        let chart = self.state();
 
         if chart.bounds.width == 0.0 {
             return vec![];

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -106,6 +106,24 @@ impl Chart for KlineChart {
         }
     }
 
+    fn autoscaled_coords(&self) -> Vector {
+        let chart = self.common_data();
+        let x_translation = match &self.kind {
+            KlineChartKind::Footprint { .. } => {
+                0.5 * (chart.bounds.width / chart.scaling) - (chart.cell_width / chart.scaling)
+            }
+            KlineChartKind::Candles => {
+                0.5 * (chart.bounds.width / chart.scaling)
+                    - (8.0 * chart.cell_width / chart.scaling)
+            }
+        };
+        Vector::new(x_translation, chart.translation.y)
+    }
+
+    fn supports_fit_autoscaling(&self) -> bool {
+        true
+    }
+
     fn is_empty(&self) -> bool {
         match &self.data_source {
             ChartData::TimeBased(timeseries) => timeseries.datapoints.is_empty(),
@@ -739,7 +757,7 @@ impl KlineChart {
                     chart.translation.y = self.data_source.latest_y_midpoint(chart);
                 }
                 super::Autoscale::FitToVisible => {
-                    if let Some((lowest, highest)) = self.data_source.fit_visible_data(chart) {
+                    if let Some((lowest, highest)) = self.data_source.visible_price_range(chart) {
                         let highest = *highest;
                         let lowest = *lowest;
 

--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -791,18 +791,15 @@ impl KlineChart {
                         .data_source
                         .visible_price_range(start_interval, end_interval)
                     {
-                        let highest = *highest;
-                        let lowest = *lowest;
-
                         let padding = (highest - lowest) * 0.05;
                         let price_span = (highest - lowest) + (2.0 * padding);
 
-                        if price_span > f32::EPSILON && chart.bounds.height > f32::EPSILON {
+                        if price_span > 0.0 && chart.bounds.height > f32::EPSILON {
                             let padded_highest = highest + padding;
                             let chart_height = chart.bounds.height;
                             let tick_size = chart.tick_size;
 
-                            if tick_size > f32::EPSILON {
+                            if tick_size > 0.0 {
                                 chart.cell_height = (chart_height * tick_size) / price_span;
                                 chart.base_price_y = padded_highest;
                                 chart.translation.y = -chart_height / 2.0;

--- a/src/chart/scale.rs
+++ b/src/chart/scale.rs
@@ -4,7 +4,7 @@ pub mod timeseries;
 use crate::{chart::TEXT_SIZE, style::AZERET_MONO};
 
 use super::{Basis, Interaction, Message};
-use data::util::round_to_tick;
+use data::{chart::Autoscale, util::round_to_tick};
 use iced::{
     Alignment, Color, Event, Point, Rectangle, Renderer, Size, Theme, mouse,
     theme::palette::Extended,
@@ -220,6 +220,7 @@ pub struct AxisLabelsX<'a> {
     pub timezone: data::UserTimezone,
     pub chart_bounds: Rectangle,
     pub interval_keys: Option<Vec<u64>>,
+    pub autoscaling: Option<Autoscale>,
 }
 
 impl AxisLabelsX<'_> {
@@ -392,7 +393,13 @@ impl canvas::Program<Message> for AxisLabelsX<'_> {
                         if difference_x.abs() > 1.0 {
                             *last_position = cursor_position;
 
-                            let message = Message::XScaling(difference_x * 0.2, 0.0, false);
+                            let delta = if self.autoscaling == Some(Autoscale::FitToVisible) {
+                                difference_x * 0.05
+                            } else {
+                                difference_x * 0.2
+                            };
+
+                            let message = Message::XScaling(delta, 0.0, false);
 
                             return Some(canvas::Action::publish(message).and_capture());
                         }

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -15,7 +15,7 @@ use crate::{
 use data::{
     UserTimezone,
     chart::{
-        Basis, ChartLayout, VisualConfig,
+        Basis, ViewConfig, VisualConfig,
         indicator::{HeatmapIndicator, Indicator, KlineIndicator},
     },
     layout::pane::Settings,
@@ -671,7 +671,7 @@ impl Content {
         } else {
             (
                 vec![HeatmapIndicator::Volume],
-                ChartLayout {
+                ViewConfig {
                     crosshair: true,
                     splits: vec![],
                     autoscale: Some(data::chart::Autoscale::CenterLatest),
@@ -771,7 +771,7 @@ impl Content {
 
         let layout = prev_layout
             .filter(|l| l.splits.len() == splits.len())
-            .unwrap_or(ChartLayout {
+            .unwrap_or(ViewConfig {
                 crosshair: true,
                 splits,
                 autoscale: Some(data::chart::Autoscale::FitToVisible),

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -674,6 +674,7 @@ impl Content {
                 ChartLayout {
                     crosshair: true,
                     splits: vec![],
+                    autoscale: Some(data::chart::Autoscale::CenterLatest),
                 },
             )
         };
@@ -773,6 +774,7 @@ impl Content {
             .unwrap_or(ChartLayout {
                 crosshair: true,
                 splits,
+                autoscale: Some(data::chart::Autoscale::FitToVisible),
             });
 
         Content::Kline(


### PR DESCRIPTION
This PR brings a new auto scaling option to `KlineChart` instances to fit the data in the y-axis range. `Autoscale::FitToVisible` provides a traditional charting experience, while `Autoscale::CenterLatest` retains the original behavior

https://github.com/user-attachments/assets/e34f663d-1d50-469d-b1e5-81947267ce30

