### PR TITLE
Pane linking, shared tickers

### DIFF
--- a/data/src/layout/dashboard.rs
+++ b/data/src/layout/dashboard.rs
@@ -5,8 +5,8 @@ use crate::layout::pane::ok_or_default;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct Dashboard {
-    #[serde(deserialize_with = "ok_or_default")]
+    #[serde(deserialize_with = "ok_or_default", default)]
     pub pane: Pane,
-    #[serde(deserialize_with = "ok_or_default")]
+    #[serde(deserialize_with = "ok_or_default", default)]
     pub popout: Vec<(Pane, WindowSpec)>,
 }

--- a/data/src/layout/pane.rs
+++ b/data/src/layout/pane.rs
@@ -15,7 +15,7 @@ pub enum Axis {
     Vertical,
 }
 
-#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum Pane {
     Split {
         axis: Axis,
@@ -23,8 +23,10 @@ pub enum Pane {
         a: Box<Pane>,
         b: Box<Pane>,
     },
-    #[default]
-    Starter,
+    Starter {
+        #[serde(deserialize_with = "ok_or_default", default)]
+        link_group: Option<LinkGroup>,
+    },
     HeatmapChart {
         layout: ViewConfig,
         #[serde(deserialize_with = "ok_or_default", default)]
@@ -35,6 +37,8 @@ pub enum Pane {
         settings: Settings,
         #[serde(deserialize_with = "ok_or_default", default)]
         indicators: Vec<HeatmapIndicator>,
+        #[serde(deserialize_with = "ok_or_default", default)]
+        link_group: Option<LinkGroup>,
     },
     KlineChart {
         layout: ViewConfig,
@@ -45,11 +49,21 @@ pub enum Pane {
         settings: Settings,
         #[serde(deserialize_with = "ok_or_default", default)]
         indicators: Vec<KlineIndicator>,
+        #[serde(deserialize_with = "ok_or_default", default)]
+        link_group: Option<LinkGroup>,
     },
     TimeAndSales {
         stream_type: Vec<StreamKind>,
         settings: Settings,
+        #[serde(deserialize_with = "ok_or_default", default)]
+        link_group: Option<LinkGroup>,
     },
+}
+
+impl Default for Pane {
+    fn default() -> Self {
+        Pane::Starter { link_group: None }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, Default)]
@@ -59,6 +73,50 @@ pub struct Settings {
     pub tick_multiply: Option<TickMultiplier>,
     pub visual_config: Option<VisualConfig>,
     pub selected_basis: Option<Basis>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub enum LinkGroup {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+}
+
+impl LinkGroup {
+    pub const ALL: [LinkGroup; 9] = [
+        LinkGroup::A,
+        LinkGroup::B,
+        LinkGroup::C,
+        LinkGroup::D,
+        LinkGroup::E,
+        LinkGroup::F,
+        LinkGroup::G,
+        LinkGroup::H,
+        LinkGroup::I,
+    ];
+}
+
+impl std::fmt::Display for LinkGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let c = match self {
+            LinkGroup::A => "1",
+            LinkGroup::B => "2",
+            LinkGroup::C => "3",
+            LinkGroup::D => "4",
+            LinkGroup::E => "5",
+            LinkGroup::F => "6",
+            LinkGroup::G => "7",
+            LinkGroup::H => "8",
+            LinkGroup::I => "9",
+        };
+        write!(f, "{c}")
+    }
 }
 
 pub fn ok_or_default<'a, T, D>(deserializer: D) -> Result<T, D::Error>

--- a/exchange/src/adapter.rs
+++ b/exchange/src/adapter.rs
@@ -125,6 +125,12 @@ impl UniqueStreams {
         self.update_specs_for_exchange(exchange);
     }
 
+    pub fn extend<'a>(&mut self, streams: impl IntoIterator<Item = &'a StreamKind>) {
+        for stream in streams {
+            self.add(*stream);
+        }
+    }
+
     fn update_specs_for_exchange(&mut self, exchange: Exchange) {
         let depth_streams = self.depth_streams(Some(exchange));
         let kline_streams = self.kline_streams(Some(exchange));

--- a/src/chart/heatmap.rs
+++ b/src/chart/heatmap.rs
@@ -42,6 +42,8 @@ const TOOLTIP_WIDTH: f32 = 180.0;
 const TOOLTIP_HEIGHT: f32 = 60.0;
 const TOOLTIP_PADDING: f32 = 12.0;
 
+const MAX_CIRCLE_RADIUS: f32 = 16.0;
+
 impl Chart for HeatmapChart {
     type IndicatorType = HeatmapIndicator;
 
@@ -698,7 +700,9 @@ impl canvas::Program<Message> for HeatmapChart {
                                 if let Some(trade_size_scale) = self.visual_config.trade_size_scale
                                 {
                                     let scale_factor = (trade_size_scale as f32) / 100.0;
-                                    1.0 + (trade.qty / max_trade_qty) * (28.0 - 1.0) * scale_factor
+                                    1.0 + (trade.qty / max_trade_qty)
+                                        * (MAX_CIRCLE_RADIUS - 1.0)
+                                        * scale_factor
                                 } else {
                                     cell_height / 2.0
                                 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -295,7 +295,7 @@ pub fn configuration(pane: data::Pane) -> Configuration<pane::State> {
 pub fn load_saved_state() -> SavedState {
     match data::read_from_file(data::SAVED_STATE_PATH) {
         Ok(state) => {
-            let mut de_layouts: Vec<(String, Dashboard)> = vec![];
+            let mut de_layouts = vec![];
 
             for layout in &state.layout_manager.layouts {
                 let mut popout_windows = Vec::new();
@@ -305,12 +305,15 @@ pub fn load_saved_state() -> SavedState {
                     popout_windows.push((configuration, *window_spec));
                 }
 
+                let layout_id = Uuid::new_v4();
+
                 let dashboard = Dashboard::from_config(
                     configuration(layout.dashboard.pane.clone()),
                     popout_windows,
+                    layout_id,
                 );
 
-                de_layouts.push((layout.name.clone(), dashboard));
+                de_layouts.push((layout.name.clone(), layout_id, dashboard));
             }
 
             let layout_manager: LayoutManager = {
@@ -323,13 +326,13 @@ pub fn load_saved_state() -> SavedState {
 
                 let mut layout_order = vec![];
 
-                for (name, dashboard) in de_layouts {
+                for (name, layout_id, dashboard) in de_layouts {
                     let layout = Layout {
                         id: {
                             if name == active_layout.name {
                                 active_layout.id
                             } else {
-                                Uuid::new_v4()
+                                layout_id
                             }
                         },
                         name,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -79,7 +79,7 @@ impl From<&Dashboard> for data::Dashboard {
                 },
                 Node::Pane(pane) => panes
                     .get(pane)
-                    .map_or(data::Pane::Starter, data::Pane::from),
+                    .map_or(data::Pane::default(), data::Pane::from),
             }
         }
 
@@ -108,13 +108,16 @@ impl From<&pane::State> for data::Pane {
         let streams = pane.streams.clone();
 
         match &pane.content {
-            pane::Content::Starter => data::Pane::Starter,
+            pane::Content::Starter => data::Pane::Starter {
+                link_group: pane.link_group,
+            },
             pane::Content::Heatmap(chart, indicators) => data::Pane::HeatmapChart {
                 layout: chart.chart_layout(),
                 stream_type: streams,
                 settings: pane.settings,
                 indicators: indicators.clone(),
                 studies: chart.studies.clone(),
+                link_group: pane.link_group,
             },
             pane::Content::Kline(chart, indicators) => data::Pane::KlineChart {
                 layout: chart.chart_layout(),
@@ -122,10 +125,12 @@ impl From<&pane::State> for data::Pane {
                 stream_type: streams,
                 settings: pane.settings,
                 indicators: indicators.clone(),
+                link_group: pane.link_group,
             },
             pane::Content::TimeAndSales(_) => data::Pane::TimeAndSales {
                 stream_type: streams,
                 settings: pane.settings,
+                link_group: pane.link_group,
             },
         }
     }
@@ -142,13 +147,19 @@ pub fn configuration(pane: data::Pane) -> Configuration<pane::State> {
             a: Box::new(configuration(*a)),
             b: Box::new(configuration(*b)),
         },
-        data::Pane::Starter => Configuration::Pane(pane::State::new()),
+        data::Pane::Starter { link_group } => Configuration::Pane(pane::State::from_config(
+            pane::Content::Starter,
+            vec![],
+            data::layout::pane::Settings::default(),
+            link_group,
+        )),
         data::Pane::HeatmapChart {
             layout,
             studies,
             stream_type,
             settings,
             indicators,
+            link_group,
         } => {
             if let Some(ticker_info) = settings.ticker_info {
                 let tick_size = settings
@@ -176,6 +187,7 @@ pub fn configuration(pane: data::Pane) -> Configuration<pane::State> {
                     ),
                     stream_type,
                     settings,
+                    link_group,
                 ))
             } else {
                 log::info!("Skipping a HeatmapChart initialization due to missing ticker info");
@@ -188,6 +200,7 @@ pub fn configuration(pane: data::Pane) -> Configuration<pane::State> {
             stream_type,
             settings,
             indicators,
+            link_group,
         } => match kind {
             data::chart::KlineChartKind::Footprint { .. } => {
                 if let Some(ticker_info) = settings.ticker_info {
@@ -213,6 +226,7 @@ pub fn configuration(pane: data::Pane) -> Configuration<pane::State> {
                         ),
                         stream_type,
                         settings,
+                        link_group,
                     ))
                 } else {
                     log::info!(
@@ -246,6 +260,7 @@ pub fn configuration(pane: data::Pane) -> Configuration<pane::State> {
                         ),
                         stream_type,
                         settings,
+                        link_group,
                     ))
                 } else {
                     log::info!(
@@ -258,6 +273,7 @@ pub fn configuration(pane: data::Pane) -> Configuration<pane::State> {
         data::Pane::TimeAndSales {
             stream_type,
             settings,
+            link_group,
         } => {
             if settings.ticker_info.is_none() {
                 log::info!("Skipping a TimeAndSales initialization due to missing ticker info");
@@ -270,6 +286,7 @@ pub fn configuration(pane: data::Pane) -> Configuration<pane::State> {
                 pane::Content::TimeAndSales(TimeAndSales::new(config, settings.ticker_info)),
                 stream_type,
                 settings,
+                link_group,
             ))
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -398,11 +398,7 @@ impl Flowsurface {
                 let (task, action) = self.sidebar.update(message);
 
                 match action {
-                    Some(dashboard::sidebar::Action::TickerSelected(
-                        ticker_info,
-                        exchange,
-                        content,
-                    )) => {
+                    Some(dashboard::sidebar::Action::TickerSelected(ticker_info, content)) => {
                         let main_window_id = self.main_window.id;
 
                         let task = {
@@ -410,15 +406,11 @@ impl Flowsurface {
                                 self.active_dashboard_mut().init_pane_task(
                                     main_window_id,
                                     ticker_info,
-                                    exchange,
                                     &content_str,
                                 )
                             } else {
-                                self.active_dashboard_mut().switch_tickers_in_group(
-                                    main_window_id,
-                                    exchange,
-                                    ticker_info,
-                                )
+                                self.active_dashboard_mut()
+                                    .switch_tickers_in_group(main_window_id, ticker_info)
                             }
                         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,12 +405,22 @@ impl Flowsurface {
                     )) => {
                         let main_window_id = self.main_window.id;
 
-                        let task = self.active_dashboard_mut().init_pane_task(
-                            main_window_id,
-                            ticker_info,
-                            exchange,
-                            &content,
-                        );
+                        let task = {
+                            if let Some(content_str) = content {
+                                self.active_dashboard_mut().init_pane_task(
+                                    main_window_id,
+                                    ticker_info,
+                                    exchange,
+                                    &content_str,
+                                )
+                            } else {
+                                self.active_dashboard_mut().switch_tickers_in_group(
+                                    main_window_id,
+                                    exchange,
+                                    ticker_info,
+                                )
+                            }
+                        };
 
                         return task.map(move |msg| Message::Dashboard(None, msg));
                     }
@@ -787,7 +797,7 @@ impl Flowsurface {
                                 tooltip(
                                     split_pane_button,
                                     if is_main_window {
-                                        Some("Split selected pane vertically")
+                                        Some("Split selected pane horizontally")
                                     } else {
                                         None
                                     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -501,8 +501,8 @@ impl Flowsurface {
             content,
             &self.notifications,
             match sidebar_pos {
-                sidebar::Position::Left => Alignment::End,
-                sidebar::Position::Right => Alignment::Start,
+                sidebar::Position::Left => Alignment::Start,
+                sidebar::Position::Right => Alignment::End,
             },
             Message::RemoveNotification,
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,7 +403,7 @@ impl Flowsurface {
 
                         let task = {
                             if let Some(content_str) = content {
-                                self.active_dashboard_mut().init_pane_task(
+                                self.active_dashboard_mut().init_focused_pane(
                                     main_window_id,
                                     ticker_info,
                                     &content_str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -739,8 +739,13 @@ impl Flowsurface {
 
                 let manage_pane = if let Some((window_id, pane_id)) = dashboard.focus {
                     let selected_pane_str =
-                        if let Some(pane) = dashboard.get_pane(main_window, window_id, pane_id) {
-                            pane.content.name()
+                        if let Some(state) = dashboard.get_pane(main_window, window_id, pane_id) {
+                            let link_group_name: String =
+                                state.link_group.as_ref().map_or_else(String::new, |g| {
+                                    " - Group ".to_string() + &g.to_string()
+                                });
+
+                            state.content.name() + &link_group_name
                         } else {
                             "".to_string()
                         };
@@ -781,46 +786,42 @@ impl Flowsurface {
                         }
                     };
 
-                    Some(
-                        column![
-                            text(selected_pane_str),
-                            row![
-                                tooltip(
-                                    reset_pane_button,
-                                    if is_main_window {
-                                        Some("Reset selected pane")
-                                    } else {
-                                        None
-                                    },
-                                    TooltipPosition::Top,
-                                ),
-                                tooltip(
-                                    split_pane_button,
-                                    if is_main_window {
-                                        Some("Split selected pane horizontally")
-                                    } else {
-                                        None
-                                    },
-                                    TooltipPosition::Top,
-                                ),
-                            ]
-                            .spacing(8)
+                    column![
+                        text(selected_pane_str),
+                        row![
+                            tooltip(
+                                reset_pane_button,
+                                if is_main_window {
+                                    Some("Reset selected pane")
+                                } else {
+                                    None
+                                },
+                                TooltipPosition::Top,
+                            ),
+                            tooltip(
+                                split_pane_button,
+                                if is_main_window {
+                                    Some("Split selected pane horizontally")
+                                } else {
+                                    None
+                                },
+                                TooltipPosition::Top,
+                            ),
                         ]
-                        .align_x(Alignment::Start)
-                        .spacing(8),
-                    )
+                        .spacing(8)
+                    ]
+                    .spacing(8)
                 } else {
-                    None
+                    column![text("No pane selected"),].spacing(8)
                 };
 
                 let manage_layout_modal = {
-                    let mut col = column![];
-                    if let Some(manage_pane) = manage_pane {
-                        col = col.push(manage_pane);
-                        col =
-                            col.push(iced::widget::horizontal_rule(1.0).style(style::split_ruler));
-                    }
-                    col = col.push(self.layout_manager.view().map(Message::Layouts));
+                    let col = column![
+                        manage_pane,
+                        iced::widget::horizontal_rule(1.0).style(style::split_ruler),
+                        self.layout_manager.view().map(Message::Layouts)
+                    ];
+
                     container(col.align_x(Alignment::Center).spacing(20))
                         .width(260)
                         .padding(24)

--- a/src/main.rs
+++ b/src/main.rs
@@ -745,7 +745,7 @@ impl Flowsurface {
                                     " - Group ".to_string() + &g.to_string()
                                 });
 
-                            state.content.name() + &link_group_name
+                            state.content.to_string() + &link_group_name
                         } else {
                             "".to_string()
                         };

--- a/src/modal/layout_manager.rs
+++ b/src/modal/layout_manager.rs
@@ -226,6 +226,7 @@ impl LayoutManager {
                     let dashboard = Dashboard::from_config(
                         configuration(ser_dashboard.pane.clone()),
                         popout_windows,
+                        layout.id,
                     );
 
                     self.layout_order.push(new_layout.id);

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use data::{UserTimezone, chart::Basis, layout::WindowSpec};
 use exchange::{
-    Kline, TickMultiplier, Ticker, TickerInfo, Timeframe, Trade,
+    Kline, Ticker, TickerInfo, Timeframe, Trade,
     adapter::{
         self, AdapterError, Exchange, StreamConfig, StreamKind, UniqueStreams, binance, bybit,
     },
@@ -41,12 +41,6 @@ pub enum Message {
     SavePopoutSpecs(HashMap<window::Id, WindowSpec>),
     ErrorOccurred(Option<uuid::Uuid>, DashboardError),
     Notification(Toast),
-    ChartRequestedFetch {
-        window: window::Id,
-        pane: pane_grid::Pane,
-        req_id: uuid::Uuid,
-        fetch: FetchRange,
-    },
     DistributeFetchedData {
         layout_id: uuid::Uuid,
         pane_id: uuid::Uuid,
@@ -60,6 +54,7 @@ pub struct Dashboard {
     pub focus: Option<(window::Id, pane_grid::Pane)>,
     pub popout: HashMap<window::Id, (pane_grid::State<pane::State>, WindowSpec)>,
     pub streams: UniqueStreams,
+    layout_id: uuid::Uuid,
 }
 
 impl Default for Dashboard {
@@ -69,6 +64,7 @@ impl Default for Dashboard {
             focus: None,
             streams: UniqueStreams::default(),
             popout: HashMap::new(),
+            layout_id: uuid::Uuid::new_v4(),
         }
     }
 }
@@ -112,6 +108,7 @@ impl Dashboard {
     pub fn from_config(
         panes: Configuration<pane::State>,
         popout_windows: Vec<(Configuration<pane::State>, WindowSpec)>,
+        layout_id: uuid::Uuid,
     ) -> Self {
         let panes = pane_grid::State::with_configuration(panes);
 
@@ -129,6 +126,7 @@ impl Dashboard {
             focus: None,
             streams: UniqueStreams::default(),
             popout,
+            layout_id,
         }
     }
 
@@ -195,330 +193,296 @@ impl Dashboard {
                     );
                 }
             },
-            Message::Pane(window, message) => {
-                match message {
-                    pane::Message::PaneClicked(pane) => {
-                        self.focus = Some((window, pane));
+            Message::Pane(window, message) => match message {
+                pane::Message::PaneClicked(pane) => {
+                    self.focus = Some((window, pane));
+                }
+                pane::Message::PaneResized(pane_grid::ResizeEvent { split, ratio }) => {
+                    self.panes.resize(split, ratio);
+                }
+                pane::Message::PaneDragged(event) => {
+                    if let pane_grid::DragEvent::Dropped { pane, target } = event {
+                        self.panes.drop(pane, target);
                     }
-                    pane::Message::PaneResized(pane_grid::ResizeEvent { split, ratio }) => {
-                        self.panes.resize(split, ratio);
-                    }
-                    pane::Message::PaneDragged(event) => {
-                        if let pane_grid::DragEvent::Dropped { pane, target } = event {
-                            self.panes.drop(pane, target);
-                        }
-                    }
-                    pane::Message::SplitPane(axis, pane) => {
-                        let focus_pane = if let Some((new_pane, _)) =
-                            self.panes.split(axis, pane, pane::State::new())
-                        {
-                            Some(new_pane)
-                        } else {
-                            None
-                        };
+                }
+                pane::Message::SplitPane(axis, pane) => {
+                    let focus_pane = if let Some((new_pane, _)) =
+                        self.panes.split(axis, pane, pane::State::new())
+                    {
+                        Some(new_pane)
+                    } else {
+                        None
+                    };
 
-                        if Some(focus_pane).is_some() {
-                            self.focus = Some((window, focus_pane.unwrap()));
-                        }
+                    if Some(focus_pane).is_some() {
+                        self.focus = Some((window, focus_pane.unwrap()));
                     }
-                    pane::Message::ClosePane(pane) => {
-                        if let Some((_, sibling)) = self.panes.close(pane) {
-                            self.focus = Some((window, sibling));
-                        }
+                }
+                pane::Message::ClosePane(pane) => {
+                    if let Some((_, sibling)) = self.panes.close(pane) {
+                        self.focus = Some((window, sibling));
                     }
-                    pane::Message::MaximizePane(pane) => {
-                        self.panes.maximize(pane);
+                }
+                pane::Message::MaximizePane(pane) => {
+                    self.panes.maximize(pane);
+                }
+                pane::Message::Restore => {
+                    self.panes.restore();
+                }
+                pane::Message::ReplacePane(pane) => {
+                    if let Some(pane) = self.panes.get_mut(pane) {
+                        *pane = pane::State::new();
                     }
-                    pane::Message::Restore => {
-                        self.panes.restore();
-                    }
-                    pane::Message::ReplacePane(pane) => {
-                        if let Some(pane) = self.panes.get_mut(pane) {
-                            *pane = pane::State::new();
-                        }
 
-                        return (self.refresh_streams(main_window.id), None);
-                    }
-                    pane::Message::ShowModal(pane, requested_modal) => {
-                        if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
-                            match &state.modal {
-                                Some(modal) if modal == &requested_modal => {
-                                    state.modal = None;
-                                }
-                                _ => {
-                                    state.modal = Some(requested_modal);
-                                }
+                    return (self.refresh_streams(main_window.id), None);
+                }
+                pane::Message::ShowModal(pane, requested_modal) => {
+                    if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
+                        match &state.modal {
+                            Some(modal) if modal == &requested_modal => {
+                                state.modal = None;
+                            }
+                            _ => {
+                                state.modal = Some(requested_modal);
                             }
                         }
                     }
-                    pane::Message::HideModal(pane) => {
-                        if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
-                            pane_state.modal = None;
-                        }
+                }
+                pane::Message::HideModal(pane) => {
+                    if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
+                        pane_state.modal = None;
                     }
-                    pane::Message::ChartInteraction(pane, msg) => {
-                        if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
-                            match state.content {
-                                pane::Content::Heatmap(ref mut chart, _) => {
-                                    chart::update(chart, msg);
-                                }
-                                pane::Content::Kline(ref mut chart, _) => {
-                                    chart::update(chart, msg);
-                                }
-                                _ => {}
+                }
+                pane::Message::ChartInteraction(pane, msg) => {
+                    if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
+                        match state.content {
+                            pane::Content::Heatmap(ref mut chart, _) => {
+                                chart::update(chart, msg);
                             }
-                        }
-                    }
-                    pane::Message::PanelInteraction(pane, msg) => {
-                        if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
-                            if let pane::Content::TimeAndSales(ref mut panel) = state.content {
-                                panel::update(panel, msg);
+                            pane::Content::Kline(ref mut chart, _) => {
+                                chart::update(chart, msg);
                             }
+                            _ => {}
                         }
                     }
-                    pane::Message::VisualConfigChanged(pane, cfg, to_sync) => {
-                        if to_sync {
-                            if let Some(state) = self.get_pane(main_window.id, window, pane) {
-                                let studies_cfg = state.content.studies();
-                                let clusters_cfg = match &state.content {
-                                    pane::Content::Kline(chart, _) => match chart.kind() {
-                                        data::chart::KlineChartKind::Footprint {
-                                            clusters, ..
-                                        } => Some(clusters.clone()),
-                                        _ => None,
-                                    },
+                }
+                pane::Message::PanelInteraction(pane, msg) => {
+                    if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
+                        if let pane::Content::TimeAndSales(ref mut panel) = state.content {
+                            panel::update(panel, msg);
+                        }
+                    }
+                }
+                pane::Message::VisualConfigChanged(pane, cfg, to_sync) => {
+                    if to_sync {
+                        if let Some(state) = self.get_pane(main_window.id, window, pane) {
+                            let studies_cfg = state.content.studies();
+                            let clusters_cfg = match &state.content {
+                                pane::Content::Kline(chart, _) => match chart.kind() {
+                                    data::chart::KlineChartKind::Footprint { clusters, .. } => {
+                                        Some(clusters.clone())
+                                    }
                                     _ => None,
-                                };
+                                },
+                                _ => None,
+                            };
 
-                                self.iter_all_panes_mut(main_window.id).for_each(
-                                    |(_, _, state)| {
-                                        let should_apply = match state.settings.visual_config {
-                                            Some(ref current_cfg) => {
-                                                std::mem::discriminant(current_cfg)
-                                                    == std::mem::discriminant(&cfg)
-                                            }
-                                            None => matches!(
-                                                (&cfg, &state.content),
-                                                (
-                                                    data::chart::VisualConfig::Kline(_),
-                                                    pane::Content::Kline(_, _)
-                                                ) | (
-                                                    data::chart::VisualConfig::Heatmap(_),
-                                                    pane::Content::Heatmap(_, _)
-                                                ) | (
-                                                    data::chart::VisualConfig::TimeAndSales(_),
-                                                    pane::Content::TimeAndSales(_)
-                                                )
-                                            ),
-                                        };
+                            self.iter_all_panes_mut(main_window.id)
+                                .for_each(|(_, _, state)| {
+                                    let should_apply = match state.settings.visual_config {
+                                        Some(ref current_cfg) => {
+                                            std::mem::discriminant(current_cfg)
+                                                == std::mem::discriminant(&cfg)
+                                        }
+                                        None => matches!(
+                                            (&cfg, &state.content),
+                                            (
+                                                data::chart::VisualConfig::Kline(_),
+                                                pane::Content::Kline(_, _)
+                                            ) | (
+                                                data::chart::VisualConfig::Heatmap(_),
+                                                pane::Content::Heatmap(_, _)
+                                            ) | (
+                                                data::chart::VisualConfig::TimeAndSales(_),
+                                                pane::Content::TimeAndSales(_)
+                                            )
+                                        ),
+                                    };
 
-                                        if should_apply {
-                                            state.settings.visual_config = Some(cfg);
-                                            state.content.change_visual_config(cfg);
+                                    if should_apply {
+                                        state.settings.visual_config = Some(cfg);
+                                        state.content.change_visual_config(cfg);
 
-                                            if let Some(studies) = &studies_cfg {
-                                                state.content.update_studies(studies.clone());
-                                            }
+                                        if let Some(studies) = &studies_cfg {
+                                            state.content.update_studies(studies.clone());
+                                        }
 
-                                            if let Some(cluster_kind) = &clusters_cfg {
-                                                if let pane::Content::Kline(chart, _) =
-                                                    &mut state.content
-                                                {
-                                                    chart.set_cluster_kind(cluster_kind.clone());
-                                                }
+                                        if let Some(cluster_kind) = &clusters_cfg {
+                                            if let pane::Content::Kline(chart, _) =
+                                                &mut state.content
+                                            {
+                                                chart.set_cluster_kind(cluster_kind.clone());
                                             }
                                         }
-                                    },
+                                    }
+                                });
+                        }
+                    } else if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
+                        state.settings.visual_config = Some(cfg);
+                        state.content.change_visual_config(cfg);
+                    }
+                }
+                pane::Message::SwitchLinkGroup(pane, group) => {
+                    let maybe_ticker_info = self
+                        .iter_all_panes(main_window.id)
+                        .filter(|(w, p, _)| !(*w == window && *p == pane))
+                        .find_map(|(_, _, other_state)| {
+                            if other_state.link_group == group {
+                                other_state.settings.ticker_info
+                            } else {
+                                None
+                            }
+                        });
+
+                    if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
+                        state.link_group = group;
+
+                        if let Some(ticker_info) = maybe_ticker_info {
+                            if state.settings.ticker_info != Some(ticker_info) {
+                                let content_kind = state.content.identifier_str();
+                                return (
+                                    self.init_focused_pane(
+                                        main_window.id,
+                                        ticker_info,
+                                        &content_kind,
+                                    ),
+                                    None,
                                 );
                             }
-                        } else if let Some(state) = self.get_mut_pane(main_window.id, window, pane)
-                        {
-                            state.settings.visual_config = Some(cfg);
-                            state.content.change_visual_config(cfg);
                         }
                     }
-                    pane::Message::SwitchLinkGroup(pane, group) => {
-                        let maybe_ticker_info = self
-                            .iter_all_panes(main_window.id)
-                            .filter(|(w, p, _)| !(*w == window && *p == pane))
-                            .find_map(|(_, _, other_state)| {
-                                if other_state.link_group == group {
-                                    other_state.settings.ticker_info
-                                } else {
-                                    None
-                                }
-                            });
-
-                        if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
-                            state.link_group = group;
-
-                            if let Some(ticker_info) = maybe_ticker_info {
-                                let content_kind = state.content.identifier_str();
-                                let task = state
-                                    .init_content_task(&content_kind, ticker_info, pane)
-                                    .map(move |msg| Message::Pane(window, msg));
-                                return (task, None);
-                            }
+                }
+                pane::Message::Popout => return (self.popout_pane(main_window), None),
+                pane::Message::Merge => return (self.merge_pane(main_window), None),
+                pane::Message::ToggleIndicator(pane, indicator_str) => {
+                    if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
+                        pane_state.content.toggle_indicator(&indicator_str);
+                    }
+                }
+                pane::Message::DeleteNotification(pane, idx) => {
+                    if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
+                        pane_state.notifications.remove(idx);
+                    }
+                }
+                pane::Message::ReorderIndicator(pane, event) => {
+                    if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
+                        pane_state.content.reorder_indicators(&event);
+                    }
+                }
+                pane::Message::ClusterKindSelected(pane, cluster_kind) => {
+                    if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
+                        if let pane::Content::Kline(chart, _) = &mut pane_state.content {
+                            chart.set_cluster_kind(cluster_kind);
                         }
                     }
-                    pane::Message::InitPaneContent(
-                        content_str,
-                        is_pane,
-                        pane_stream,
-                        ticker_info,
-                    ) => {
-                        let pane;
-                        if let Some(parent_pane) = is_pane {
-                            pane = parent_pane;
-                        } else {
-                            pane = self
-                                .panes
-                                .iter()
-                                .next()
-                                .map(|(pane, _)| *pane)
-                                .expect("No pane found");
-                        }
-
-                        let err_occurred =
-                            |pane_uid, err| Task::done(Message::ErrorOccurred(pane_uid, err));
-
-                        // prepare unique streams for websocket
-                        for stream in &pane_stream {
-                            self.streams.add(*stream);
-                        }
-
-                        // set pane's stream and content identifiers
-                        if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
-                            let pane_id = state.unique_id();
-
-                            if let Err(err) = state.set_content(ticker_info, &content_str) {
-                                return (err_occurred(Some(pane_id), err), None);
-                            }
-
-                            // get fetch tasks for pane's content
-                            for stream in &pane_stream {
-                                if let StreamKind::Kline { .. } = stream {
-                                    return (
-                                        kline_fetch_task(*layout_id, pane_id, *stream, None, None),
-                                        None,
-                                    );
+                }
+                pane::Message::StudyConfigurator(pane, study_msg) => {
+                    if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
+                        match study_msg {
+                            StudyMessage::Footprint(message) => {
+                                if let pane::Content::Kline(chart, _) = &mut pane_state.content {
+                                    chart.update_study_configurator(message);
                                 }
                             }
-                        } else {
-                            return (
-                                err_occurred(
-                                    None,
-                                    DashboardError::PaneSet("No pane found".to_string()),
-                                ),
-                                None,
-                            );
-                        }
-                    }
-                    pane::Message::Popout => return (self.popout_pane(main_window), None),
-                    pane::Message::Merge => return (self.merge_pane(main_window), None),
-                    pane::Message::ToggleIndicator(pane, indicator_str) => {
-                        if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
-                            pane_state.content.toggle_indicator(&indicator_str);
-                        }
-                    }
-                    pane::Message::DeleteNotification(pane, idx) => {
-                        if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
-                            pane_state.notifications.remove(idx);
-                        }
-                    }
-                    pane::Message::ReorderIndicator(pane, event) => {
-                        if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
-                            pane_state.content.reorder_indicators(&event);
-                        }
-                    }
-                    pane::Message::ClusterKindSelected(pane, cluster_kind) => {
-                        if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
-                            if let pane::Content::Kline(chart, _) = &mut pane_state.content {
-                                chart.set_cluster_kind(cluster_kind);
+                            StudyMessage::Heatmap(message) => {
+                                if let pane::Content::Heatmap(chart, _) = &mut pane_state.content {
+                                    chart.update_study_configurator(message);
+                                }
                             }
                         }
                     }
-                    pane::Message::StudyConfigurator(pane, study_msg) => {
-                        if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
-                            match study_msg {
-                                StudyMessage::Footprint(message) => {
-                                    if let pane::Content::Kline(chart, _) = &mut pane_state.content
+                }
+                pane::Message::StreamModifierChanged(pane, message) => {
+                    if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
+                        if let Some(pane::Modal::StreamModifier(mut modifier)) = state.modal {
+                            let action = modifier.update(message);
+
+                            match action {
+                                Some(modal::stream::Action::TabSelected(tab)) => {
+                                    modifier.tab = tab;
+
+                                    state.modal = Some(pane::Modal::StreamModifier(modifier));
+                                }
+                                Some(modal::stream::Action::BasisSelected(new_basis)) => {
+                                    modifier.update_kind_with_basis(new_basis);
+
+                                    state.modal = Some(pane::Modal::StreamModifier(modifier));
+
+                                    state.settings.selected_basis = Some(new_basis);
+
+                                    if let pane::Content::Heatmap(ref mut chart, _) = state.content
                                     {
-                                        chart.update_study_configurator(message);
+                                        chart.set_basis(new_basis);
+                                        return (Task::none(), None);
                                     }
-                                }
-                                StudyMessage::Heatmap(message) => {
-                                    if let pane::Content::Heatmap(chart, _) =
-                                        &mut pane_state.content
-                                    {
-                                        chart.update_study_configurator(message);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    pane::Message::StreamModifierChanged(pane, message) => {
-                        if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
-                            if let Some(pane::Modal::StreamModifier(mut modifier)) = state.modal {
-                                let action = modifier.update(message);
 
-                                match action {
-                                    Some(modal::stream::Action::TabSelected(tab)) => {
-                                        modifier.tab = tab;
+                                    if let Some((exchange, ticker)) = state.stream_pair() {
+                                        let chart_kind =
+                                            state.content.chart_kind().unwrap_or_default();
+                                        let is_footprint = matches!(
+                                            chart_kind,
+                                            data::chart::KlineChartKind::Footprint { .. }
+                                        );
 
-                                        state.modal = Some(pane::Modal::StreamModifier(modifier));
-                                    }
-                                    Some(modal::stream::Action::BasisSelected(new_basis)) => {
-                                        modifier.update_kind_with_basis(new_basis);
+                                        match new_basis {
+                                            Basis::Time(new_tf) => {
+                                                let mut streams = vec![StreamKind::Kline {
+                                                    exchange,
+                                                    ticker,
+                                                    timeframe: new_tf,
+                                                }];
 
-                                        state.modal = Some(pane::Modal::StreamModifier(modifier));
-
-                                        state.settings.selected_basis = Some(new_basis);
-
-                                        if let pane::Content::Heatmap(ref mut chart, _) =
-                                            state.content
-                                        {
-                                            chart.set_basis(new_basis);
-                                            return (Task::none(), None);
-                                        }
-
-                                        if let Some((exchange, ticker)) = state.stream_pair() {
-                                            let chart_kind =
-                                                state.content.chart_kind().unwrap_or_default();
-                                            let is_footprint = matches!(
-                                                chart_kind,
-                                                data::chart::KlineChartKind::Footprint { .. }
-                                            );
-
-                                            match new_basis {
-                                                Basis::Time(timeframe) => {
-                                                    let mut streams = vec![StreamKind::Kline {
+                                                if is_footprint {
+                                                    streams.push(StreamKind::DepthAndTrades {
                                                         exchange,
                                                         ticker,
-                                                        timeframe,
-                                                    }];
+                                                    });
+                                                }
 
-                                                    if is_footprint {
-                                                        streams.push(StreamKind::DepthAndTrades {
-                                                            exchange,
-                                                            ticker,
-                                                        });
+                                                state.streams = streams;
+
+                                                let pane_id = state.unique_id();
+
+                                                state.settings.selected_basis =
+                                                    Some(Basis::Time(new_tf));
+
+                                                if let Some(stream_type) =
+                                                    state.streams.iter_mut().find(|stream_type| {
+                                                        matches!(
+                                                            stream_type,
+                                                            StreamKind::Kline { .. }
+                                                        )
+                                                    })
+                                                {
+                                                    if let StreamKind::Kline { timeframe, .. } =
+                                                        stream_type
+                                                    {
+                                                        *timeframe = new_tf;
                                                     }
 
-                                                    state.streams = streams;
-
-                                                    match self.set_pane_timeframe(
-                                                        main_window.id,
-                                                        window,
-                                                        pane,
-                                                        timeframe,
-                                                    ) {
-                                                        Ok((stream, pane_uid)) => {
-                                                            if let StreamKind::Kline { .. } = stream
+                                                    if let pane::Content::Kline(_, _) =
+                                                        &state.content
+                                                    {
+                                                        {
+                                                            if let StreamKind::Kline { .. } =
+                                                                stream_type
                                                             {
                                                                 let task = kline_fetch_task(
-                                                                    *layout_id, pane_uid, *stream,
-                                                                    None, None,
+                                                                    *layout_id,
+                                                                    pane_id,
+                                                                    *stream_type,
+                                                                    None,
+                                                                    None,
                                                                 );
                                                                 return (
                                                                     self.refresh_streams(
@@ -529,185 +493,60 @@ impl Dashboard {
                                                                 );
                                                             }
                                                         }
-                                                        Err(err) => {
-                                                            return (
-                                                                Task::done(Message::ErrorOccurred(
-                                                                    None, err,
-                                                                )),
-                                                                None,
-                                                            );
-                                                        }
                                                     }
                                                 }
-                                                Basis::Tick(interval) => {
-                                                    state.streams =
-                                                        vec![StreamKind::DepthAndTrades {
-                                                            exchange,
-                                                            ticker,
-                                                        }];
+                                            }
+                                            Basis::Tick(interval) => {
+                                                state.streams = vec![StreamKind::DepthAndTrades {
+                                                    exchange,
+                                                    ticker,
+                                                }];
 
-                                                    if let Some(pane_state) = self.get_mut_pane(
-                                                        main_window.id,
-                                                        window,
-                                                        pane,
-                                                    ) {
-                                                        if let pane::Content::Kline(chart, _) =
-                                                            &mut pane_state.content
-                                                        {
-                                                            chart.set_tick_basis(interval);
-                                                        }
+                                                if let Some(pane_state) =
+                                                    self.get_mut_pane(main_window.id, window, pane)
+                                                {
+                                                    if let pane::Content::Kline(chart, _) =
+                                                        &mut pane_state.content
+                                                    {
+                                                        chart.set_tick_basis(interval);
                                                     }
                                                 }
                                             }
                                         }
-
-                                        return (self.refresh_streams(main_window.id), None);
                                     }
-                                    Some(modal::stream::Action::TicksizeSelected(
-                                        new_multiplier,
-                                    )) => {
-                                        modifier.update_kind_with_multiplier(new_multiplier);
 
-                                        state.modal = Some(pane::Modal::StreamModifier(modifier));
+                                    return (self.refresh_streams(main_window.id), None);
+                                }
+                                Some(modal::stream::Action::TicksizeSelected(new_multiplier)) => {
+                                    modifier.update_kind_with_multiplier(new_multiplier);
 
-                                        return (
-                                            self.set_pane_ticksize(
-                                                main_window.id,
-                                                window,
-                                                pane,
-                                                new_multiplier,
-                                            ),
-                                            None,
-                                        );
+                                    state.modal = Some(pane::Modal::StreamModifier(modifier));
+                                    state.settings.tick_multiply = Some(new_multiplier);
+
+                                    if let Some(ticker_info) = state.settings.ticker_info {
+                                        match state.content {
+                                            pane::Content::Kline(ref mut chart, _) => {
+                                                chart.change_tick_size(
+                                                    new_multiplier
+                                                        .multiply_with_min_tick_size(ticker_info),
+                                                );
+
+                                                chart.reset_request_handler();
+                                            }
+                                            pane::Content::Heatmap(ref mut chart, _) => {
+                                                chart.change_tick_size(
+                                                    new_multiplier
+                                                        .multiply_with_min_tick_size(ticker_info),
+                                                );
+                                            }
+                                            _ => {}
+                                        }
                                     }
-                                    None => {
-                                        state.modal = Some(pane::Modal::StreamModifier(modifier));
-                                    }
+                                }
+                                None => {
+                                    state.modal = Some(pane::Modal::StreamModifier(modifier));
                                 }
                             }
-                        }
-                    }
-                }
-            }
-            Message::ChartRequestedFetch {
-                pane,
-                window,
-                req_id,
-                fetch,
-            } => match fetch {
-                FetchRange::Kline(from, to) => {
-                    let kline_stream =
-                        self.get_mut_pane(main_window.id, window, pane)
-                            .and_then(|state| {
-                                let pane_id = state.unique_id();
-
-                                state
-                                    .streams
-                                    .iter()
-                                    .find(|stream| matches!(stream, StreamKind::Kline { .. }))
-                                    .map(|stream| (*stream, pane_id))
-                            });
-
-                    if let Some((stream, pane_uid)) = kline_stream {
-                        return (
-                            kline_fetch_task(
-                                *layout_id,
-                                pane_uid,
-                                stream,
-                                Some(req_id),
-                                Some((from, to)),
-                            ),
-                            None,
-                        );
-                    }
-                }
-                FetchRange::OpenInterest(from, to) => {
-                    let kline_stream =
-                        self.get_mut_pane(main_window.id, window, pane)
-                            .and_then(|state| {
-                                let pane_id = state.unique_id();
-
-                                state
-                                    .streams
-                                    .iter()
-                                    .find(|stream| matches!(stream, StreamKind::Kline { .. }))
-                                    .map(|stream| (*stream, pane_id))
-                            });
-
-                    if let Some((stream, pane_uid)) = kline_stream {
-                        return (
-                            oi_fetch_task(
-                                *layout_id,
-                                pane_uid,
-                                stream,
-                                Some(req_id),
-                                Some((from, to)),
-                            ),
-                            None,
-                        );
-                    }
-                }
-                FetchRange::Trades(from_time, to_time) => {
-                    let trade_info =
-                        self.get_pane(main_window.id, window, pane)
-                            .and_then(|state| {
-                                let pane_id = state.unique_id();
-
-                                state.streams.iter().find_map(|stream| {
-                                    if let StreamKind::DepthAndTrades { exchange, ticker } = stream
-                                    {
-                                        Some((*exchange, *ticker, pane_id, *stream))
-                                    } else {
-                                        None
-                                    }
-                                })
-                            });
-
-                    if let Some((exchange, ticker, pane_id, stream)) = trade_info {
-                        let is_binance = matches!(
-                            exchange,
-                            Exchange::BinanceSpot
-                                | Exchange::BinanceLinear
-                                | Exchange::BinanceInverse
-                        );
-
-                        if is_binance {
-                            let data_path = data::data_path(Some("market_data/binance/"));
-                            let dashboard_id = *layout_id;
-
-                            let (task, handle) = Task::sip(
-                                fetch_trades_batched(ticker, from_time, to_time, data_path),
-                                move |batch| {
-                                    let data = FetchedData::Trades {
-                                        batch,
-                                        until_time: to_time,
-                                    };
-                                    Message::DistributeFetchedData {
-                                        layout_id: dashboard_id,
-                                        pane_id,
-                                        data,
-                                        stream,
-                                    }
-                                },
-                                move |result| match result {
-                                    Ok(()) => {
-                                        Message::ChangePaneStatus(pane_id, pane::Status::Ready)
-                                    }
-                                    Err(err) => Message::ErrorOccurred(
-                                        Some(pane_id),
-                                        DashboardError::Fetch(err.to_string()),
-                                    ),
-                                },
-                            )
-                            .abortable();
-
-                            if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
-                                if let pane::Content::Kline(chart, _) = &mut state.content {
-                                    chart.set_handle(handle.abort_on_drop());
-                                }
-                            };
-
-                            return (task, None);
                         }
                     }
                 }
@@ -982,113 +821,73 @@ impl Dashboard {
         false
     }
 
-    fn set_pane_ticksize(
+    fn handle_error(
         &mut self,
+        pane_id: Option<uuid::Uuid>,
+        err: DashboardError,
         main_window: window::Id,
-        window: window::Id,
-        pane: pane_grid::Pane,
-        new_tick_multiply: TickMultiplier,
     ) -> Task<Message> {
-        if let Some(state) = self.get_mut_pane(main_window, window, pane) {
-            state.settings.tick_multiply = Some(new_tick_multiply);
-
-            let pane_id = state.unique_id();
-
-            if let Some(ticker_info) = state.settings.ticker_info {
-                match state.content {
-                    pane::Content::Kline(ref mut chart, _) => {
-                        chart.change_tick_size(
-                            new_tick_multiply.multiply_with_min_tick_size(ticker_info),
-                        );
-
-                        chart.reset_request_handler();
-                    }
-                    pane::Content::Heatmap(ref mut chart, _) => {
-                        chart.change_tick_size(
-                            new_tick_multiply.multiply_with_min_tick_size(ticker_info),
-                        );
-                    }
-                    _ => {
-                        return Task::done(Message::ErrorOccurred(
-                            Some(pane_id),
-                            DashboardError::PaneSet(
-                                "No chart found to change ticksize".to_string(),
-                            ),
-                        ));
-                    }
+        match pane_id {
+            Some(id) => {
+                if let Some(state) = self.get_mut_pane_state_by_uuid(main_window, id) {
+                    state.status = pane::Status::Ready;
+                    state.notifications.push(Toast::error(err.to_string()));
                 }
-            } else {
-                return Task::done(Message::ErrorOccurred(
-                    Some(pane_id),
-                    DashboardError::PaneSet("No min ticksize found".to_string()),
-                ));
+                Task::none()
             }
-        } else {
-            return Task::done(Message::ErrorOccurred(
-                None,
-                DashboardError::PaneSet("No pane found to change ticksize".to_string()),
-            ));
+            _ => Task::done(Message::Notification(Toast::error(err.to_string()))),
         }
-
-        Task::none()
     }
 
-    fn set_pane_timeframe(
+    fn init_pane(
         &mut self,
         main_window: window::Id,
         window: window::Id,
-        pane: pane_grid::Pane,
-        new_timeframe: Timeframe,
-    ) -> Result<(&StreamKind, uuid::Uuid), DashboardError> {
-        if let Some(state) = self.get_mut_pane(main_window, window, pane) {
-            let pane_id = state.unique_id();
-
-            state.settings.selected_basis = Some(Basis::Time(new_timeframe));
-
-            if let Some(stream_type) = state
-                .streams
-                .iter_mut()
-                .find(|stream_type| matches!(stream_type, StreamKind::Kline { .. }))
-            {
-                if let StreamKind::Kline { timeframe, .. } = stream_type {
-                    *timeframe = new_timeframe;
-                }
-
-                if let pane::Content::Kline(_, _) = &state.content {
-                    return Ok((stream_type, pane_id));
-                }
-            }
-        }
-        Err(DashboardError::Unknown(
-            "Couldn't get the pane to change its timeframe".to_string(),
-        ))
-    }
-
-    pub fn init_pane_task(
-        &mut self,
-        main_window: window::Id,
+        selected_pane: pane_grid::Pane,
         ticker_info: TickerInfo,
         content: &str,
     ) -> Task<Message> {
-        if let Some((window, selected_pane)) = self.focus {
-            if let Some(pane_state) = self.get_mut_pane(main_window, window, selected_pane) {
-                let previous_ticker_info = pane_state.settings.ticker_info.as_ref();
+        let layout_id = self.layout_id;
 
-                if previous_ticker_info.is_some() && previous_ticker_info != Some(&ticker_info) {
-                    pane_state.link_group = None;
-                }
+        if let Some(state) = self.get_mut_pane(main_window, window, selected_pane) {
+            let pane_id = state.unique_id();
+            let pane_streams = state.prepare_streams(content, ticker_info);
 
-                return pane_state
-                    .init_content_task(content, ticker_info, selected_pane)
-                    .map(move |msg| Message::Pane(window, msg));
+            if let Err(err) = state.set_content(ticker_info, &content) {
+                state.status = pane::Status::Ready;
+                state.notifications.push(Toast::error(err.to_string()));
             }
-        } else {
-            return Task::done(Message::Notification(Toast::warn(
-                "Select a pane first".to_string(),
-            )));
+
+            for stream in &pane_streams {
+                self.streams.add(*stream);
+                if let StreamKind::Kline { .. } = stream {
+                    return kline_fetch_task(layout_id, pane_id, *stream, None, None);
+                }
+            }
         }
 
         Task::none()
+    }
+
+    pub fn init_focused_pane(
+        &mut self,
+        main_window: window::Id,
+        ticker_info: TickerInfo,
+        content_kind: &str,
+    ) -> Task<Message> {
+        if let Some((window, selected_pane)) = self.focus {
+            return self.init_pane(
+                main_window,
+                window,
+                selected_pane,
+                ticker_info,
+                content_kind,
+            );
+        }
+
+        Task::done(Message::Notification(Toast::warn(
+            "No focused pane found".to_string(),
+        )))
     }
 
     pub fn switch_tickers_in_group(
@@ -1102,20 +901,21 @@ impl Dashboard {
         });
 
         if let Some(group) = link_group {
-            let tasks: Vec<_> = self
+            let pane_infos: Vec<(window::Id, pane_grid::Pane, String)> = self
                 .iter_all_panes_mut(main_window)
                 .filter_map(|(window, pane, state)| {
                     if state.link_group == Some(group) {
-                        let content_kind = &state.content.identifier_str();
-
-                        Some(
-                            state
-                                .init_content_task(content_kind, ticker_info, pane)
-                                .map(move |msg| Message::Pane(window, msg)),
-                        )
+                        Some((window, pane, state.content.identifier_str()))
                     } else {
                         None
                     }
+                })
+                .collect();
+
+            let tasks: Vec<Task<Message>> = pane_infos
+                .iter()
+                .map(|(window, pane, content)| {
+                    self.init_pane(main_window, *window, *pane, ticker_info, &content)
                 })
                 .collect();
 
@@ -1123,13 +923,10 @@ impl Dashboard {
         } else if let Some((window, pane)) = self.focus {
             if let Some(state) = self.get_mut_pane(main_window, window, pane) {
                 let content_kind = &state.content.identifier_str();
-
-                state
-                    .init_content_task(content_kind, ticker_info, pane)
-                    .map(move |msg| Message::Pane(window, msg))
+                self.init_focused_pane(main_window, ticker_info, content_kind)
             } else {
                 Task::done(Message::Notification(Toast::warn(
-                    "No focused pane found".to_string(),
+                    "Couldn't get focused pane's content".to_string(),
                 )))
             }
         } else {
@@ -1171,7 +968,7 @@ impl Dashboard {
                     if let Err(reason) =
                         self.insert_fetched_trades(main_window, pane_id, &batch, false)
                     {
-                        return Task::done(Message::ErrorOccurred(Some(pane_id), reason));
+                        return self.handle_error(Some(pane_id), reason, main_window);
                     }
                 } else {
                     let filtered_batch = batch
@@ -1183,7 +980,7 @@ impl Dashboard {
                     if let Err(reason) =
                         self.insert_fetched_trades(main_window, pane_id, &filtered_batch, true)
                     {
-                        return Task::done(Message::ErrorOccurred(Some(pane_id), reason));
+                        return self.handle_error(Some(pane_id), reason, main_window);
                     }
                 }
             }
@@ -1326,27 +1123,20 @@ impl Dashboard {
 
     pub fn tick(&mut self, now: Instant, main_window: window::Id) -> Task<Message> {
         let mut tasks = vec![];
+        let layout_id = self.layout_id;
 
         self.iter_all_panes_mut(main_window)
-            .for_each(|(window, pane, state)| match state.tick(now) {
-                Some(pane::Action::Chart(chart_action)) => match chart_action {
+            .for_each(|(_, _, state)| match state.tick(now) {
+                Some(pane::Action::Chart(action)) => match action {
                     chart::Action::ErrorOccurred(err) => {
-                        let pane_id = state.unique_id();
-
-                        tasks.push(Task::done(Message::ErrorOccurred(
-                            Some(pane_id),
-                            DashboardError::Unknown(err.to_string()),
-                        )));
+                        state.status = pane::Status::Ready;
+                        state.notifications.push(Toast::error(err.to_string()));
                     }
                     chart::Action::FetchRequested(req_id, fetch) => {
-                        tasks.push(Task::done(Message::ChartRequestedFetch {
-                            pane,
-                            window,
-                            req_id,
-                            fetch,
-                        }));
+                        tasks.push(request_fetch(state, layout_id, req_id, fetch));
                     }
                 },
+                Some(pane::Action::Panel(_action)) => {}
                 None => {}
             });
 
@@ -1354,9 +1144,9 @@ impl Dashboard {
     }
 
     pub fn market_subscriptions(&self) -> Subscription<exchange::Event> {
-        let stream_specs = self.streams.combined();
-
-        let unique_streams = stream_specs
+        let unique_streams = self
+            .streams
+            .combined()
             .iter()
             .flat_map(|(exchange, specs)| {
                 let mut subs = vec![];
@@ -1450,6 +1240,102 @@ impl Dashboard {
 
         Task::batch(tasks)
     }
+}
+
+fn request_fetch(
+    state: &mut pane::State,
+    layout_id: uuid::Uuid,
+    req_id: uuid::Uuid,
+    fetch: FetchRange,
+) -> Task<Message> {
+    let pane_id = state.unique_id();
+
+    match fetch {
+        FetchRange::Kline(from, to) => {
+            let kline_stream = {
+                state
+                    .streams
+                    .iter()
+                    .find(|stream| matches!(stream, StreamKind::Kline { .. }))
+                    .map(|stream| (*stream, pane_id))
+            };
+
+            if let Some((stream, pane_uid)) = kline_stream {
+                return kline_fetch_task(
+                    layout_id,
+                    pane_uid,
+                    stream,
+                    Some(req_id),
+                    Some((from, to)),
+                );
+            }
+        }
+        FetchRange::OpenInterest(from, to) => {
+            let kline_stream = {
+                state
+                    .streams
+                    .iter()
+                    .find(|stream| matches!(stream, StreamKind::Kline { .. }))
+                    .map(|stream| (*stream, pane_id))
+            };
+
+            if let Some((stream, pane_uid)) = kline_stream {
+                return oi_fetch_task(layout_id, pane_uid, stream, Some(req_id), Some((from, to)));
+            }
+        }
+        FetchRange::Trades(from_time, to_time) => {
+            let trade_info = state.streams.iter().find_map(|stream| {
+                if let StreamKind::DepthAndTrades { exchange, ticker } = stream {
+                    Some((*exchange, *ticker, pane_id, *stream))
+                } else {
+                    None
+                }
+            });
+
+            if let Some((exchange, ticker, pane_id, stream)) = trade_info {
+                let is_binance = matches!(
+                    exchange,
+                    Exchange::BinanceSpot | Exchange::BinanceLinear | Exchange::BinanceInverse
+                );
+
+                if is_binance {
+                    let data_path = data::data_path(Some("market_data/binance/"));
+
+                    let (task, handle) = Task::sip(
+                        fetch_trades_batched(ticker, from_time, to_time, data_path),
+                        move |batch| {
+                            let data = FetchedData::Trades {
+                                batch,
+                                until_time: to_time,
+                            };
+                            Message::DistributeFetchedData {
+                                layout_id,
+                                pane_id,
+                                data,
+                                stream,
+                            }
+                        },
+                        move |result| match result {
+                            Ok(()) => Message::ChangePaneStatus(pane_id, pane::Status::Ready),
+                            Err(err) => Message::ErrorOccurred(
+                                Some(pane_id),
+                                DashboardError::Fetch(err.to_string()),
+                            ),
+                        },
+                    )
+                    .abortable();
+
+                    if let pane::Content::Kline(chart, _) = &mut state.content {
+                        chart.set_handle(handle.abort_on_drop());
+                    }
+
+                    return task;
+                }
+            }
+        }
+    }
+
+    Task::none()
 }
 
 fn oi_fetch_task(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -337,9 +337,9 @@ impl Dashboard {
                             state.content.change_visual_config(cfg);
                         }
                     }
-                    pane::Message::SwitchLinkGroup(pane) => {
+                    pane::Message::SwitchLinkGroup(pane, group) => {
                         if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
-                            state.link_group = pane::LinkGroup::next(state.link_group);
+                            state.link_group = group;
                         }
                     }
                     pane::Message::InitPaneContent(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -1083,15 +1083,7 @@ impl Dashboard {
                 .iter_all_panes_mut(main_window)
                 .filter_map(|(window, pane, state)| {
                     if state.link_group == Some(group) {
-                        let content_kind = match &state.content {
-                            pane::Content::Heatmap(_, _) => "heatmap",
-                            pane::Content::Kline(chart, _) => match chart.kind() {
-                                data::chart::KlineChartKind::Candles => "candlestick",
-                                data::chart::KlineChartKind::Footprint { .. } => "footprint",
-                            },
-                            pane::Content::TimeAndSales(_) => "time&sales",
-                            _ => return None,
-                        };
+                        let content_kind = &state.content.identifier_str();
 
                         Some(
                             state
@@ -1107,19 +1099,7 @@ impl Dashboard {
             Task::batch(tasks)
         } else if let Some((window, pane)) = self.focus {
             if let Some(state) = self.get_mut_pane(main_window, window, pane) {
-                let content_kind = match &state.content {
-                    pane::Content::Heatmap(_, _) => "heatmap",
-                    pane::Content::Kline(chart, _) => match chart.kind() {
-                        data::chart::KlineChartKind::Candles => "candlestick",
-                        data::chart::KlineChartKind::Footprint { .. } => "footprint",
-                    },
-                    pane::Content::TimeAndSales(_) => "time&sales",
-                    _ => {
-                        return Task::done(Message::Notification(Toast::warn(
-                            "Focused pane does not support switching ticker".to_string(),
-                        )));
-                    }
-                };
+                let content_kind = &state.content.identifier_str();
 
                 state
                     .init_content_task(content_kind, exchange, ticker_info, pane)

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -28,7 +28,7 @@ use exchange::{
     adapter::{Exchange, MarketKind, StreamKind},
 };
 use iced::{
-    Alignment, Element, Length, Renderer, Task, Theme,
+    Alignment, Element, Length, Renderer, Theme,
     alignment::Vertical,
     padding,
     widget::{button, center, column, container, pane_grid, row, text, tooltip},
@@ -76,7 +76,6 @@ pub enum Message {
     Restore,
     ShowModal(pane_grid::Pane, Modal),
     HideModal(pane_grid::Pane),
-    InitPaneContent(String, Option<pane_grid::Pane>, Vec<StreamKind>, TickerInfo),
     ReplacePane(pane_grid::Pane),
     ChartInteraction(pane_grid::Pane, chart::Message),
     PanelInteraction(pane_grid::Pane, panel::Message),
@@ -135,12 +134,7 @@ impl State {
             .next()
     }
 
-    pub fn init_content_task(
-        &mut self,
-        content: &str,
-        ticker_info: TickerInfo,
-        pane: pane_grid::Pane,
-    ) -> Task<Message> {
+    pub fn prepare_streams(&mut self, content: &str, ticker_info: TickerInfo) -> Vec<StreamKind> {
         let (exchange, ticker) = (ticker_info.exchange(), ticker_info.ticker);
 
         if (matches!(&self.content, Content::Heatmap(_, _)) && content != "heatmap")
@@ -196,12 +190,7 @@ impl State {
 
         self.streams.clone_from(&streams);
 
-        Task::done(Message::InitPaneContent(
-            content.to_string(),
-            Some(pane),
-            streams,
-            ticker_info,
-        ))
+        streams
     }
 
     pub fn set_content(

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -749,28 +749,31 @@ impl State {
         let mut grid = column![].spacing(4);
         let rows = LinkGroup::ALL.chunks(3);
 
-        let create_button = |content: iced::widget::text::Text<'a>,
-                             msg: Message,
-                             is_selected: bool| {
-            button(content.align_x(iced::Alignment::Center))
-                .width(Length::Fixed(26.0))
-                .on_press(msg)
-                .style(move |theme, status| style::button::menu_body(theme, status, is_selected))
-        };
-
         for row_groups in rows {
             let mut button_row = row![].spacing(4);
+
             for &group in row_groups {
-                button_row = button_row.push(create_button(
-                    text(group.to_string()),
-                    if self.link_group == Some(group) {
-                        Message::SwitchLinkGroup(pane, None)
-                    } else {
-                        Message::SwitchLinkGroup(pane, Some(group))
-                    },
-                    self.link_group == Some(group),
-                ));
+                let is_selected = self.link_group == Some(group);
+                let btn_content = text(group.to_string()).font(style::AZERET_MONO);
+
+                let btn = if is_selected {
+                    button_with_tooltip(
+                        btn_content.align_x(iced::Alignment::Center),
+                        Message::SwitchLinkGroup(pane, None),
+                        Some("Unlink"),
+                        tooltip::Position::Bottom,
+                        move |theme, status| style::button::menu_body(theme, status, true),
+                    )
+                } else {
+                    button(btn_content.align_x(iced::Alignment::Center))
+                        .on_press(Message::SwitchLinkGroup(pane, Some(group)))
+                        .style(move |theme, status| style::button::menu_body(theme, status, false))
+                        .into()
+                };
+
+                button_row = button_row.push(btn);
             }
+
             grid = grid.push(button_row);
         }
 
@@ -1139,7 +1142,8 @@ fn link_group_button<'a>(
 
     let icon = if let Some(group) = link_group {
         text(group.to_string())
-            .align_x(Alignment::Center)
+            .font(style::AZERET_MONO)
+            .align_x(Alignment::Start)
             .align_y(Alignment::Center)
     } else {
         icon_text(Icon::Link, 13)
@@ -1147,10 +1151,10 @@ fn link_group_button<'a>(
             .align_y(Alignment::Center)
     };
 
-    button(link_group.map_or(icon, |g| text(g.to_string())))
+    button(icon)
         .style(move |theme, status| style::button::menu_body(theme, status, is_active))
         .on_press(Message::ShowModal(id, Modal::LinkGroup))
-        .width(26)
+        .width(28)
         .into()
 }
 

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -138,10 +138,11 @@ impl State {
     pub fn init_content_task(
         &mut self,
         content: &str,
-        exchange: Exchange,
         ticker_info: TickerInfo,
         pane: pane_grid::Pane,
     ) -> Task<Message> {
+        let (exchange, ticker) = (ticker_info.exchange(), ticker_info.ticker);
+
         if (matches!(&self.content, Content::Heatmap(_, _)) && content != "heatmap")
             || (matches!(&self.content, Content::Kline(_, _)) && content == "heatmap")
         {
@@ -150,10 +151,7 @@ impl State {
 
         let streams = match content {
             "heatmap" | "time&sales" => {
-                vec![StreamKind::DepthAndTrades {
-                    exchange,
-                    ticker: ticker_info.ticker,
-                }]
+                vec![StreamKind::DepthAndTrades { exchange, ticker }]
             }
             "footprint" => {
                 let basis = self.settings.selected_basis.unwrap_or(Timeframe::M5.into());
@@ -161,22 +159,16 @@ impl State {
                 match basis {
                     Basis::Time(timeframe) => {
                         vec![
-                            StreamKind::DepthAndTrades {
-                                exchange,
-                                ticker: ticker_info.ticker,
-                            },
+                            StreamKind::DepthAndTrades { exchange, ticker },
                             StreamKind::Kline {
                                 exchange,
-                                ticker: ticker_info.ticker,
+                                ticker,
                                 timeframe,
                             },
                         ]
                     }
                     Basis::Tick(_) => {
-                        vec![StreamKind::DepthAndTrades {
-                            exchange,
-                            ticker: ticker_info.ticker,
-                        }]
+                        vec![StreamKind::DepthAndTrades { exchange, ticker }]
                     }
                 }
             }
@@ -190,15 +182,12 @@ impl State {
                     Basis::Time(timeframe) => {
                         vec![StreamKind::Kline {
                             exchange,
-                            ticker: ticker_info.ticker,
+                            ticker,
                             timeframe,
                         }]
                     }
                     Basis::Tick(_) => {
-                        vec![StreamKind::DepthAndTrades {
-                            exchange,
-                            ticker: ticker_info.ticker,
-                        }]
+                        vec![StreamKind::DepthAndTrades { exchange, ticker }]
                     }
                 }
             }

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -21,7 +21,7 @@ use data::{
         Basis, ViewConfig, VisualConfig,
         indicator::{HeatmapIndicator, Indicator, KlineIndicator},
     },
-    layout::pane::Settings,
+    layout::pane::{LinkGroup, Settings},
 };
 use exchange::{
     Kline, OpenInterest, TickMultiplier, Ticker, TickerInfo, Timeframe,
@@ -92,50 +92,6 @@ pub enum Message {
     SwitchLinkGroup(pane_grid::Pane, Option<LinkGroup>),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum LinkGroup {
-    A,
-    B,
-    C,
-    D,
-    E,
-    F,
-    G,
-    H,
-    I,
-}
-
-impl LinkGroup {
-    pub const ALL: [LinkGroup; 9] = [
-        LinkGroup::A,
-        LinkGroup::B,
-        LinkGroup::C,
-        LinkGroup::D,
-        LinkGroup::E,
-        LinkGroup::F,
-        LinkGroup::G,
-        LinkGroup::H,
-        LinkGroup::I,
-    ];
-}
-
-impl std::fmt::Display for LinkGroup {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let c = match self {
-            LinkGroup::A => "1",
-            LinkGroup::B => "2",
-            LinkGroup::C => "3",
-            LinkGroup::D => "4",
-            LinkGroup::E => "5",
-            LinkGroup::F => "6",
-            LinkGroup::G => "7",
-            LinkGroup::H => "8",
-            LinkGroup::I => "9",
-        };
-        write!(f, "{c}")
-    }
-}
-
 pub struct State {
     id: uuid::Uuid,
     pub modal: Option<Modal>,
@@ -152,11 +108,17 @@ impl State {
         Self::default()
     }
 
-    pub fn from_config(content: Content, streams: Vec<StreamKind>, settings: Settings) -> Self {
+    pub fn from_config(
+        content: Content,
+        streams: Vec<StreamKind>,
+        settings: Settings,
+        link_group: Option<LinkGroup>,
+    ) -> Self {
         Self {
             content,
             settings,
             streams,
+            link_group,
             ..Default::default()
         }
     }
@@ -431,7 +393,7 @@ impl State {
                         ))
                         .style(style::chart_modal),
                         Message::HideModal(id),
-                        padding::right(2).left(12),
+                        padding::left(12),
                         Alignment::End,
                     )
                 } else {
@@ -730,7 +692,7 @@ impl State {
                     column![].into()
                 },
                 Message::HideModal(pane),
-                padding::right(2).left(12),
+                padding::left(12),
                 Alignment::End,
             ),
             None => base,
@@ -772,7 +734,7 @@ impl State {
                     column![].into()
                 },
                 Message::HideModal(pane),
-                padding::right(2).left(12),
+                padding::left(12),
                 Alignment::End,
             ),
             _ => base,

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -12,7 +12,7 @@ use crate::{
         dashboard::panel::{self, timeandsales::TimeAndSales},
     },
     style::{self, Icon, icon_text},
-    widget::{self, button_with_tooltip, column_drag, toast::Toast},
+    widget::{self, button_with_tooltip, column_drag, link_group_button, toast::Toast},
     window::{self, Window},
 };
 use data::{
@@ -297,7 +297,9 @@ impl State {
         let mut stream_info_element = if Content::Starter == self.content {
             row![]
         } else {
-            row![link_group_button(id, self.link_group)]
+            row![link_group_button(id, self.link_group, |id| {
+                Message::ShowModal(id, Modal::LinkGroup)
+            })]
         };
 
         if let Some((exchange, ticker)) = self.stream_pair() {
@@ -1112,30 +1114,6 @@ fn link_group_modal<'a>(
         padding::right(12).left(4),
         Alignment::Start,
     )
-}
-
-fn link_group_button<'a>(
-    id: pane_grid::Pane,
-    link_group: Option<LinkGroup>,
-) -> Element<'a, Message> {
-    let is_active = link_group.is_some();
-
-    let icon = if let Some(group) = link_group {
-        text(group.to_string())
-            .font(style::AZERET_MONO)
-            .align_x(Alignment::Start)
-            .align_y(Alignment::Center)
-    } else {
-        icon_text(Icon::Link, 13)
-            .align_x(Alignment::Center)
-            .align_y(Alignment::Center)
-    };
-
-    button(icon)
-        .style(move |theme, status| style::button::menu_body(theme, status, is_active))
-        .on_press(Message::ShowModal(id, Modal::LinkGroup))
-        .width(28)
-        .into()
 }
 
 fn ticksize_modifier<'a>(

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -26,11 +26,7 @@ pub struct Sidebar {
 }
 
 pub enum Action {
-    TickerSelected(
-        exchange::TickerInfo,
-        exchange::adapter::Exchange,
-        Option<String>,
-    ),
+    TickerSelected(exchange::TickerInfo, Option<String>),
     ErrorOccurred(data::InternalError),
 }
 
@@ -59,10 +55,10 @@ impl Sidebar {
                 let action = self.tickers_table.update(msg);
 
                 match action {
-                    Some(tickers_table::Action::TickerSelected(ticker_info, exchange, content)) => {
+                    Some(tickers_table::Action::TickerSelected(ticker_info, content)) => {
                         return (
                             Task::none(),
-                            Some(Action::TickerSelected(ticker_info, exchange, content)),
+                            Some(Action::TickerSelected(ticker_info, content)),
                         );
                     }
                     Some(tickers_table::Action::Fetch(task)) => {

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -26,7 +26,11 @@ pub struct Sidebar {
 }
 
 pub enum Action {
-    TickerSelected(exchange::TickerInfo, exchange::adapter::Exchange, String),
+    TickerSelected(
+        exchange::TickerInfo,
+        exchange::adapter::Exchange,
+        Option<String>,
+    ),
     ErrorOccurred(data::InternalError),
 }
 

--- a/src/screen/dashboard/tickers_table.rs
+++ b/src/screen/dashboard/tickers_table.rs
@@ -41,7 +41,7 @@ pub fn fetch_tickers_info() -> Task<Message> {
 }
 
 pub enum Action {
-    TickerSelected(TickerInfo, Exchange, Option<String>),
+    TickerSelected(TickerInfo, Option<String>),
     ErrorOccurred(data::InternalError),
     Fetch(Task<Message>),
 }
@@ -341,7 +341,7 @@ impl TickersTable {
                     .flatten();
 
                 if let Some(ticker_info) = ticker_info {
-                    return Some(Action::TickerSelected(ticker_info, exchange, content));
+                    return Some(Action::TickerSelected(ticker_info, content));
                 } else {
                     log::warn!("Ticker info not found for {ticker:?} on {exchange:?}");
                 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -300,8 +300,8 @@ pub mod button {
                         Some(palette.background.weakest.color.into())
                     }
                 }
-                Status::Pressed => Some(palette.background.strongest.color.into()),
-                Status::Hovered => Some(palette.background.strong.color.into()),
+                Status::Pressed => Some(palette.background.base.color.into()),
+                Status::Hovered => Some(palette.background.weak.color.into()),
                 Status::Disabled => {
                     if is_selected {
                         None

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -214,6 +214,78 @@ where
         .into()
 }
 
+pub fn link_group_button<'a, Message, F>(
+    id: iced::widget::pane_grid::Pane,
+    link_group: Option<data::layout::pane::LinkGroup>,
+    on_press: F,
+) -> Element<'a, Message>
+where
+    Message: Clone + 'static,
+    F: Fn(iced::widget::pane_grid::Pane) -> Message + 'static,
+{
+    let is_active = link_group.is_some();
+
+    let icon = if let Some(group) = link_group {
+        text(group.to_string())
+            .font(style::AZERET_MONO)
+            .align_x(Alignment::Start)
+            .align_y(Alignment::Center)
+    } else {
+        text("-")
+            .font(style::AZERET_MONO)
+            .align_x(Alignment::Start)
+            .align_y(Alignment::Center)
+    };
+
+    button(icon)
+        .style(move |theme: &Theme, status| {
+            let palette = theme.extended_palette();
+
+            iced::widget::button::Style {
+                text_color: if is_active {
+                    palette.secondary.strong.color
+                } else {
+                    palette.secondary.base.color
+                },
+                border: iced::Border {
+                    radius: 3.0.into(),
+                    width: if is_active { 2.0 } else { 1.0 },
+                    color: if is_active {
+                        palette.background.strong.color
+                    } else {
+                        palette.background.weak.color
+                    },
+                },
+                background: match status {
+                    iced::widget::button::Status::Active => {
+                        if is_active {
+                            Some(palette.background.base.color.into())
+                        } else {
+                            Some(palette.background.weakest.color.into())
+                        }
+                    }
+                    iced::widget::button::Status::Pressed => {
+                        Some(palette.background.weakest.color.into())
+                    }
+                    iced::widget::button::Status::Hovered => {
+                        Some(palette.background.weak.color.into())
+                    }
+                    iced::widget::button::Status::Disabled => {
+                        if is_active {
+                            None
+                        } else {
+                            Some(palette.secondary.base.color.into())
+                        }
+                    }
+                },
+                ..Default::default()
+            }
+        })
+        .on_press(on_press(id))
+        .width(28)
+        .into()
+}
+
 #[macro_export]
 /// Creates a column with horizontal rules between each item.
 ///


### PR DESCRIPTION
This PR introduces linking/grouping for panes. It can be used to quickly switch tickers for multiple panes, while keeping their content types/settings 

Also brings some refactors to avoid `Task::done`'s,  redundant `Message`s etc. 


https://github.com/user-attachments/assets/1cdec5fc-9c73-47a0-8eee-94f8acec194c

