### PR TITLE
Ensure parent directory exists when writing state file

### DIFF
--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -34,9 +34,15 @@ pub enum InternalError {
 
 pub fn write_json_to_file(json: &str, file_name: &str) -> std::io::Result<()> {
     let path = data_path(Some(file_name));
-    if let Some(parent) = path.parent() {
+
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid state file path")
+    })?;
+
+    if !parent.exists() {
         std::fs::create_dir_all(parent)?;
     }
+
     let mut file = File::create(path)?;
     file.write_all(json.as_bytes())?;
     Ok(())


### PR DESCRIPTION
In Release builds, the logger setup also initializes the application data directory (e.g., AppData/Roaming/flowsurface). However, in Debug builds, logging is directed only to stdout, so the data directory is never created.
As a result, when write_json_to_file later attempts to save the application state, it fails because the parent directory does not exist.