### PR TITLE
Fix panic when sorting prices containing NaN in test

### DIFF
--- a/exchange/src/adapter/hyperliquid.rs
+++ b/exchange/src/adapter/hyperliquid.rs
@@ -1216,7 +1216,7 @@ mod tests {
     use super::*;
 
     fn smallest_positive_gap(mut prices: Vec<f32>) -> Option<f32> {
-        prices.sort_by(|a, b| b.partial_cmp(a).unwrap());
+        prices.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
         let mut best: Option<f32> = None;
         for w in prices.windows(2) {
             if w[0] != w[1] {


### PR DESCRIPTION
## Summary
Fixes a potential panic in the `smallest_positive_gap` test helper function when input prices contain NaN values.

## Bug Description
In `exchange/src/adapter/hyperliquid.rs`, the `smallest_positive_gap` function panics when sorting prices that contain NaN:

```rust
fn smallest_positive_gap(mut prices: Vec<f32>) -> Option<f32> {
    prices.sort_by(|a, b| b.partial_cmp(a).unwrap());  // Panics if a or b is NaN!
    // ...
}
```

The `partial_cmp` method returns `None` when comparing NaN values (per IEEE 754 floating point spec), causing `.unwrap()` to panic.

## Root Cause
Using `.unwrap()` on `partial_cmp` without handling the NaN case.

## Fix
Changed to `.unwrap_or(std::cmp::Ordering::Equal)` to treat NaN values as equal during sorting:

```rust
prices.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
```

This prevents the panic while maintaining correct sort behavior for valid numbers.

## Impact
- This is currently only used in test code (`#[cfg(test)]` module)
- Makes the code more defensive against unexpected NaN inputs
- No change in behavior for valid floating point inputs

## Testing
The fix ensures that if test data ever contains NaN values (e.g., from invalid price feeds or calculation errors), the test helper won't panic.