### PR TITLE
fix: kline chart bugfix in initaial start

### DIFF
--- a/src/chart/kline.rs
+++ b/src/chart/kline.rs
@@ -78,21 +78,7 @@ impl Chart for KlineChart {
             return None;
         }
 
-        match &chart.basis {
-            Basis::Time(timeframe) => {
-                let interval = timeframe.to_milliseconds();
-
-                let (earliest, latest) = (
-                    chart.x_to_interval(region.x) - (interval / 2),
-                    chart.x_to_interval(region.x + region.width) + (interval / 2),
-                );
-
-                Some((earliest, latest))
-            }
-            Basis::Tick(_) => {
-                unimplemented!()
-            }
-        }
+        Some(chart.interval_range(&region))
     }
 
     fn interval_keys(&self) -> Option<Vec<u64>> {


### PR DESCRIPTION
The bug sometimes appears in hyperliquid or mexc(probably in others if you have slow connection) when you start app in with 1 candlestick graph. Kline stream data is slow on those exchanges so latest_x in ViewState is 0 before the bug. Because of that we get: attempt to subtract with overflow crash