### PR TITLE
feat: add TPO (Market Profile) panel

### DIFF
--- a/data/src/layout/pane.rs
+++ b/data/src/layout/pane.rs
@@ -2,7 +2,7 @@ use exchange::{TickMultiplier, TickerInfo, Timeframe};
 use serde::{Deserialize, Serialize};
 
 use crate::chart::{comparison, heatmap, kline};
-use crate::panel::{ladder, timeandsales};
+use crate::panel::{ladder, timeandsales, tpo};
 use crate::stream::PersistStreamKind;
 use crate::util::ok_or_default;
 
@@ -87,6 +87,13 @@ pub enum Pane {
         #[serde(deserialize_with = "ok_or_default", default)]
         link_group: Option<LinkGroup>,
     },
+    TpoPanel {
+        stream_type: Vec<PersistStreamKind>,
+        #[serde(deserialize_with = "ok_or_default")]
+        settings: Settings,
+        #[serde(deserialize_with = "ok_or_default", default)]
+        link_group: Option<LinkGroup>,
+    },
 }
 
 impl Default for Pane {
@@ -155,6 +162,7 @@ pub enum VisualConfig {
     Kline(kline::Config),
     Ladder(ladder::Config),
     Comparison(comparison::Config),
+    Tpo(tpo::Config),
 }
 
 impl VisualConfig {
@@ -192,6 +200,13 @@ impl VisualConfig {
             _ => None,
         }
     }
+
+    pub fn tpo(&self) -> Option<tpo::Config> {
+        match self {
+            Self::Tpo(cfg) => Some(*cfg),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -204,10 +219,11 @@ pub enum ContentKind {
     ComparisonChart,
     TimeAndSales,
     Ladder,
+    TpoPanel,
 }
 
 impl ContentKind {
-    pub const ALL: [ContentKind; 8] = [
+    pub const ALL: [ContentKind; 9] = [
         ContentKind::Starter,
         ContentKind::HeatmapChart,
         ContentKind::ShaderHeatmap,
@@ -216,6 +232,7 @@ impl ContentKind {
         ContentKind::ComparisonChart,
         ContentKind::TimeAndSales,
         ContentKind::Ladder,
+        ContentKind::TpoPanel,
     ];
 }
 
@@ -230,6 +247,7 @@ impl std::fmt::Display for ContentKind {
             ContentKind::ComparisonChart => "Comparison Chart",
             ContentKind::TimeAndSales => "Time&Sales",
             ContentKind::Ladder => "DOM/Ladder",
+            ContentKind::TpoPanel => "TPO Panel",
         };
         write!(f, "{s}")
     }
@@ -297,7 +315,7 @@ impl PaneSetup {
                         Basis::default_kline_time(Some(base_ticker), Timeframe::M15)
                     }))
                 }
-                ContentKind::Starter | ContentKind::TimeAndSales => None,
+                ContentKind::Starter | ContentKind::TimeAndSales | ContentKind::TpoPanel => None,
             };
 
         let tick_multiplier = match content_kind {
@@ -319,6 +337,7 @@ impl PaneSetup {
             ContentKind::CandlestickChart
             | ContentKind::ComparisonChart
             | ContentKind::TimeAndSales
+            | ContentKind::TpoPanel
             | ContentKind::Starter => current_tick_multiplier,
         };
 

--- a/data/src/panel.rs
+++ b/data/src/panel.rs
@@ -1,2 +1,3 @@
 pub mod ladder;
 pub mod timeandsales;
+pub mod tpo;

--- a/data/src/panel/tpo.rs
+++ b/data/src/panel/tpo.rs
@@ -1,0 +1,243 @@
+use exchange::unit::{Price, PriceStep};
+use exchange::{Kline, TickerInfo};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+pub const LETTERS: &[char] = &[
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+    'S', 'T', 'U', 'V', 'W', 'X',
+];
+
+const VALUE_AREA_PCT: f64 = 0.70;
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq)]
+pub struct Config {
+    pub period_ms: u64,
+    pub session_ms: u64,
+    pub show_value_area: bool,
+    pub show_poc: bool,
+    pub show_ib: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            period_ms: 1_800_000,
+            session_ms: 86_400_000,
+            show_value_area: true,
+            show_poc: true,
+            show_ib: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TpoPeriod {
+    pub start_ms: u64,
+    pub letter_idx: usize,
+    pub prices: Vec<i64>,
+}
+
+impl TpoPeriod {
+    pub fn letter(&self) -> char {
+        LETTERS[self.letter_idx % LETTERS.len()]
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TpoProfile {
+    pub session_start_ms: u64,
+    pub periods: Vec<TpoPeriod>,
+    pub price_counts: HashMap<i64, usize>,
+    pub poc: Option<i64>,
+    pub va_high: Option<i64>,
+    pub va_low: Option<i64>,
+    pub ib_high: Option<i64>,
+    pub ib_low: Option<i64>,
+    pub price_min: Option<i64>,
+    pub price_max: Option<i64>,
+}
+
+impl TpoProfile {
+    pub fn compute_analytics(&mut self, ib_periods: usize) {
+        if self.price_counts.is_empty() {
+            return;
+        }
+
+        let poc = self
+            .price_counts
+            .iter()
+            .max_by_key(|(_, &cnt)| cnt)
+            .map(|(&p, _)| p);
+        self.poc = poc;
+
+        let mut sorted: Vec<i64> = self.price_counts.keys().copied().collect();
+        sorted.sort_unstable();
+        self.price_min = sorted.first().copied();
+        self.price_max = sorted.last().copied();
+
+        if let Some(poc_price) = poc {
+            let total: usize = self.price_counts.values().sum();
+            let va_target = ((total as f64 * VALUE_AREA_PCT).ceil() as usize).min(total);
+            let poc_idx = sorted.partition_point(|&p| p < poc_price);
+            let mut accumulated = self.price_counts.get(&poc_price).copied().unwrap_or(0);
+            let mut lo = poc_idx;
+            let mut hi = poc_idx;
+
+            while accumulated < va_target {
+                let above = if hi + 1 < sorted.len() {
+                    self.price_counts.get(&sorted[hi + 1]).copied().unwrap_or(0)
+                } else {
+                    0
+                };
+                let below = if lo > 0 {
+                    self.price_counts.get(&sorted[lo - 1]).copied().unwrap_or(0)
+                } else {
+                    0
+                };
+                if above == 0 && below == 0 {
+                    break;
+                }
+                if above >= below && hi + 1 < sorted.len() {
+                    hi += 1;
+                    accumulated += above;
+                } else if lo > 0 {
+                    lo -= 1;
+                    accumulated += below;
+                } else if hi + 1 < sorted.len() {
+                    hi += 1;
+                    accumulated += above;
+                } else {
+                    break;
+                }
+            }
+
+            self.va_low = sorted.get(lo).copied();
+            self.va_high = sorted.get(hi).copied();
+        }
+
+        let ib_count = ib_periods.min(self.periods.len());
+        if ib_count > 0 {
+            let mut ib_prices: Vec<i64> = self.periods[..ib_count]
+                .iter()
+                .flat_map(|p| p.prices.iter().copied())
+                .collect();
+            ib_prices.sort_unstable();
+            self.ib_low = ib_prices.first().copied();
+            self.ib_high = ib_prices.last().copied();
+        }
+    }
+}
+
+pub struct TpoData {
+    pub config: Config,
+    pub profiles: BTreeMap<u64, TpoProfile>,
+    current_period_prices: HashSet<i64>,
+    current_period_start: Option<u64>,
+    current_session_start: Option<u64>,
+    tick_units: i64,
+}
+
+impl TpoData {
+    pub fn new(ticker_info: TickerInfo, config: Option<Config>) -> Self {
+        let config = config.unwrap_or_default();
+        let step: PriceStep = ticker_info.min_ticksize.into();
+        let tick_units = step.units.max(1);
+        Self {
+            config,
+            profiles: BTreeMap::new(),
+            current_period_prices: HashSet::new(),
+            current_period_start: None,
+            current_session_start: None,
+            tick_units,
+        }
+    }
+
+    pub fn add_kline(&mut self, kline: &Kline) {
+        let time_ms = kline.time;
+        let period_ms = self.config.period_ms;
+        let session_ms = self.config.session_ms;
+        let session_start = (time_ms / session_ms) * session_ms;
+        let period_start = (time_ms / period_ms) * period_ms;
+
+        let new_session = self.current_session_start != Some(session_start);
+        if new_session {
+            self.flush_current_period();
+            if let Some(s) = self.current_session_start {
+                if let Some(profile) = self.profiles.get_mut(&s) {
+                    profile.compute_analytics(2);
+                }
+            }
+            self.current_session_start = Some(session_start);
+            self.current_period_start = Some(period_start);
+            self.current_period_prices.clear();
+            self.profiles.entry(session_start).or_insert_with(|| TpoProfile {
+                session_start_ms: session_start,
+                ..Default::default()
+            });
+        } else {
+            let new_period = self.current_period_start != Some(period_start);
+            if new_period {
+                self.flush_current_period();
+                self.current_period_start = Some(period_start);
+                self.current_period_prices.clear();
+            }
+        }
+
+        let low_tick = kline.low.units / self.tick_units;
+        let high_tick = kline.high.units / self.tick_units;
+        for tick in low_tick..=high_tick {
+            self.current_period_prices.insert(tick * self.tick_units);
+        }
+    }
+
+    pub fn flush_current_period(&mut self) {
+        let Some(period_start) = self.current_period_start else {
+            return;
+        };
+        let Some(session_start) = self.current_session_start else {
+            return;
+        };
+        if self.current_period_prices.is_empty() {
+            return;
+        }
+        let profile = self.profiles.entry(session_start).or_insert_with(|| TpoProfile {
+            session_start_ms: session_start,
+            ..Default::default()
+        });
+        if profile.periods.last().map(|p| p.start_ms) == Some(period_start) {
+            return;
+        }
+        let letter_idx = profile.periods.len();
+        let mut prices: Vec<i64> = self.current_period_prices.iter().copied().collect();
+        prices.sort_unstable();
+        for &p in &prices {
+            *profile.price_counts.entry(p).or_insert(0) += 1;
+        }
+        profile.periods.push(TpoPeriod {
+            start_ms: period_start,
+            letter_idx,
+            prices,
+        });
+    }
+
+    pub fn load_klines(&mut self, klines: &[Kline]) {
+        for kline in klines {
+            self.add_kline(kline);
+        }
+        self.flush_current_period();
+        if let Some(s) = self.current_session_start {
+            if let Some(profile) = self.profiles.get_mut(&s) {
+                profile.compute_analytics(2);
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.profiles.is_empty()
+    }
+
+    pub fn sorted_profiles(&self) -> Vec<&TpoProfile> {
+        self.profiles.values().collect()
+    }
+}

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -959,6 +959,9 @@ impl Dashboard {
                         pane::Content::Comparison(Some(c)) => {
                             c.update_latest_kline(&stream.ticker_info(), kline);
                         }
+                        pane::Content::TpoPanel(Some(p)) => {
+                            p.insert_kline(kline);
+                        }
                         _ => {}
                     }
                     found_match = true;

--- a/src/screen/dashboard/pane.rs
+++ b/src/screen/dashboard/pane.rs
@@ -16,7 +16,7 @@ use crate::{
         },
     },
     screen::dashboard::{
-        panel::{self, ladder::Ladder, timeandsales::TimeAndSales},
+        panel::{self, ladder::Ladder, timeandsales::TimeAndSales, tpo::TpoPanel},
         tickers_table::TickersTable,
     },
     style::{self, Icon, icon_text},
@@ -396,6 +396,24 @@ impl State {
 
                     (content, streams)
                 }
+                ContentKind::TpoPanel => {
+                    let config = self
+                        .settings
+                        .visual_config
+                        .clone()
+                        .and_then(|cfg| cfg.tpo());
+                    let content = Content::TpoPanel(Some(TpoPanel::new(
+                        config,
+                        derived_plan.ticker_info,
+                    )));
+
+                    let streams = vec![StreamKind::Kline {
+                        ticker_info: derived_plan.ticker_info,
+                        timeframe: exchange::Timeframe::M30,
+                    }];
+
+                    (content, streams)
+                }
                 ContentKind::Starter => unreachable!(),
             }
         };
@@ -482,6 +500,15 @@ impl State {
                         &[ticker_info],
                         Some(chart.serializable_config()),
                     );
+                }
+            }
+            Content::TpoPanel(Some(panel)) => {
+                if req_id.is_none() {
+                    panel.load_klines(klines);
+                } else {
+                    for k in klines {
+                        panel.insert_kline(k);
+                    }
                 }
             }
             _ => {
@@ -768,6 +795,34 @@ impl State {
                     )
                 } else {
                     let base = uninitialized_base(ContentKind::Ladder);
+                    self.compose_stack_view(
+                        base,
+                        id,
+                        None,
+                        compact_controls,
+                        || column![].into(),
+                        None,
+                        tickers_table,
+                    )
+                }
+            }
+            Content::TpoPanel(panel) => {
+                if let Some(panel) = panel {
+                    let base = panel::view(panel, timezone).map(move |message| {
+                        Message::PaneEvent(id, Event::PanelInteraction(message))
+                    });
+
+                    self.compose_stack_view(
+                        base,
+                        id,
+                        None,
+                        compact_controls,
+                        || column![].into(),
+                        None,
+                        tickers_table,
+                    )
+                } else {
+                    let base = uninitialized_base(ContentKind::TpoPanel);
                     self.compose_stack_view(
                         base,
                         id,
@@ -1153,6 +1208,7 @@ impl State {
             Event::PanelInteraction(msg) => match &mut self.content {
                 Content::Ladder(Some(p)) => super::panel::update(p, msg),
                 Content::TimeAndSales(Some(p)) => super::panel::update(p, msg),
+                Content::TpoPanel(Some(p)) => super::panel::update(p, msg),
                 _ => {}
             },
             Event::ToggleIndicator(ind) => {
@@ -1754,6 +1810,9 @@ impl State {
             Content::Ladder(panel) => panel
                 .as_mut()
                 .and_then(|p| p.invalidate(Some(now)).map(Action::Panel)),
+            Content::TpoPanel(panel) => panel
+                .as_mut()
+                .and_then(|p| p.invalidate(Some(now)).map(Action::Panel)),
             Content::Starter => None,
             Content::Comparison(chart) => chart
                 .as_mut()
@@ -1781,7 +1840,7 @@ impl State {
                     None
                 }
             }
-            Content::Ladder(_) | Content::TimeAndSales(_) => Some(100),
+            Content::Ladder(_) | Content::TimeAndSales(_) | Content::TpoPanel(_) => Some(100),
             Content::ShaderHeatmap { .. } => None,
             Content::Starter => None,
         }
@@ -1869,6 +1928,7 @@ pub enum Content {
     TimeAndSales(Option<TimeAndSales>),
     Ladder(Option<Ladder>),
     Comparison(Option<ComparisonChart>),
+    TpoPanel(Option<TpoPanel>),
 }
 
 impl Content {
@@ -2074,6 +2134,7 @@ impl Content {
             ContentKind::ComparisonChart => Content::Comparison(None),
             ContentKind::TimeAndSales => Content::TimeAndSales(None),
             ContentKind::Ladder => Content::Ladder(None),
+            ContentKind::TpoPanel => Content::TpoPanel(None),
         }
     }
 
@@ -2083,6 +2144,7 @@ impl Content {
             Content::Kline { chart, .. } => Some(chart.as_ref()?.last_update()),
             Content::TimeAndSales(panel) => Some(panel.as_ref()?.last_update()),
             Content::Ladder(panel) => Some(panel.as_ref()?.last_update()),
+            Content::TpoPanel(panel) => Some(panel.as_ref()?.last_update()),
             Content::Comparison(chart) => Some(chart.as_ref()?.last_update()),
             Content::Starter => None,
             Content::ShaderHeatmap { chart, .. } => Some(chart.as_ref()?.last_tick?),
@@ -2263,6 +2325,7 @@ impl Content {
             },
             Content::TimeAndSales(_) => ContentKind::TimeAndSales,
             Content::Ladder(_) => ContentKind::Ladder,
+            Content::TpoPanel(_) => ContentKind::TpoPanel,
             Content::Comparison(_) => ContentKind::ComparisonChart,
             Content::Starter => ContentKind::Starter,
             Content::ShaderHeatmap { .. } => ContentKind::ShaderHeatmap,
@@ -2282,6 +2345,7 @@ impl Content {
             Content::Kline { chart, .. } => chart.is_some(),
             Content::TimeAndSales(panel) => panel.is_some(),
             Content::Ladder(panel) => panel.is_some(),
+            Content::TpoPanel(panel) => panel.is_some(),
             Content::Comparison(chart) => chart.is_some(),
             Content::Starter => true,
         }

--- a/src/screen/dashboard/panel.rs
+++ b/src/screen/dashboard/panel.rs
@@ -1,5 +1,6 @@
 pub mod ladder;
 pub mod timeandsales;
+pub mod tpo;
 
 use iced::{
     Element, padding,

--- a/src/screen/dashboard/panel/tpo.rs
+++ b/src/screen/dashboard/panel/tpo.rs
@@ -1,0 +1,276 @@
+use super::Message;
+use crate::style;
+use data::panel::tpo::{Config, TpoData};
+use exchange::unit::{Price, PriceStep};
+use exchange::{Kline, TickerInfo};
+
+use iced::widget::canvas::{self, Text};
+use iced::{Alignment, Event, Point, Rectangle, Renderer, Size, Theme, mouse};
+use std::time::Instant;
+
+const TEXT_SIZE: iced::Pixels = iced::Pixels(10.0);
+const PRICE_LABEL_WIDTH: f32 = 64.0;
+const LETTER_WIDTH: f32 = 10.0;
+const ROW_HEIGHT_MAX: f32 = 14.0;
+const ROW_HEIGHT_MIN: f32 = 2.0;
+const SESSION_GAP: f32 = 8.0;
+
+pub struct TpoPanel {
+    data: TpoData,
+    ticker_info: TickerInfo,
+    pub config: Config,
+    cache: canvas::Cache,
+    scroll_x: f32,
+    last_tick: Instant,
+}
+
+impl TpoPanel {
+    pub fn new(config: Option<Config>, ticker_info: TickerInfo) -> Self {
+        let cfg = config.unwrap_or_default();
+        Self {
+            data: TpoData::new(ticker_info, Some(cfg)),
+            ticker_info,
+            config: cfg,
+            cache: canvas::Cache::default(),
+            scroll_x: 0.0,
+            last_tick: Instant::now(),
+        }
+    }
+
+    pub fn insert_kline(&mut self, kline: &Kline) {
+        self.data.add_kline(kline);
+        self.cache.clear();
+        self.last_tick = Instant::now();
+    }
+
+    pub fn load_klines(&mut self, klines: &[Kline]) {
+        self.data.load_klines(klines);
+        self.cache.clear();
+        self.last_tick = Instant::now();
+    }
+
+    pub fn last_update(&self) -> Instant {
+        self.last_tick
+    }
+
+    fn total_content_width(&self) -> f32 {
+        self.data
+            .sorted_profiles()
+            .iter()
+            .map(|p| p.periods.len() as f32 * LETTER_WIDTH + SESSION_GAP)
+            .sum::<f32>()
+    }
+}
+
+impl super::Panel for TpoPanel {
+    fn scroll(&mut self, delta: f32) {
+        let max_x = (self.total_content_width() - 100.0).max(0.0);
+        self.scroll_x = (self.scroll_x + delta).clamp(-max_x, 0.0);
+        self.cache.clear();
+    }
+
+    fn reset_scroll(&mut self) {
+        self.scroll_x = 0.0;
+        self.cache.clear();
+    }
+
+    fn invalidate(&mut self, now: Option<Instant>) -> Option<super::Action> {
+        self.cache.clear();
+        if let Some(t) = now {
+            self.last_tick = t;
+        }
+        None
+    }
+
+    fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+impl canvas::Program<Message> for TpoPanel {
+    type State = ();
+
+    fn update(
+        &self,
+        _state: &mut Self::State,
+        event: &Event,
+        _bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Option<canvas::Action<Message>> {
+        if let Event::Mouse(mouse::Event::WheelScrolled { delta }) = event {
+            let scroll = match delta {
+                mouse::ScrollDelta::Lines { x, y } => (*x + *y) * 20.0,
+                mouse::ScrollDelta::Pixels { x, y } => *x + *y,
+            };
+            return Some(canvas::Action::publish(Message::Scrolled(scroll)).and_capture());
+        }
+        None
+    }
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let content = self.cache.draw(renderer, bounds.size(), |frame| {
+            let palette = theme.extended_palette();
+            let profiles = self.data.sorted_profiles();
+            if profiles.is_empty() {
+                return;
+            }
+
+            let price_min = profiles.iter().filter_map(|p| p.price_min).min();
+            let price_max = profiles.iter().filter_map(|p| p.price_max).max();
+            let (price_min, price_max) = match (price_min, price_max) {
+                (Some(lo), Some(hi)) => (lo, hi),
+                _ => return,
+            };
+
+            let step: PriceStep = self.ticker_info.min_ticksize.into();
+            let tick_units = step.units.max(1);
+            let price_levels = ((price_max - price_min) / tick_units + 1).max(1) as usize;
+            let row_h =
+                (bounds.height / price_levels as f32).clamp(ROW_HEIGHT_MIN, ROW_HEIGHT_MAX);
+
+            frame.fill_rectangle(
+                Point::ORIGIN,
+                Size::new(PRICE_LABEL_WIDTH, bounds.height),
+                palette.background.weak.color,
+            );
+
+            let mut cursor_x = PRICE_LABEL_WIDTH + self.scroll_x;
+
+            for profile in &profiles {
+                let profile_width = profile.periods.len() as f32 * LETTER_WIDTH;
+                if cursor_x + profile_width < PRICE_LABEL_WIDTH || cursor_x > bounds.width {
+                    cursor_x += profile_width + SESSION_GAP;
+                    continue;
+                }
+
+                if self.config.show_ib {
+                    if let (Some(ib_lo), Some(ib_hi)) = (profile.ib_low, profile.ib_high) {
+                        let y_top = ((price_max - ib_hi) / tick_units) as f32 * row_h;
+                        let y_bot = ((price_max - ib_lo) / tick_units + 1) as f32 * row_h;
+                        let draw_x = cursor_x.max(PRICE_LABEL_WIDTH);
+                        frame.fill_rectangle(
+                            Point::new(draw_x, y_top),
+                            Size::new(profile_width, (y_bot - y_top).max(0.0)),
+                            palette.success.weak.color.scale_alpha(0.07),
+                        );
+                        for &border_y in &[y_top, y_bot] {
+                            frame.fill_rectangle(
+                                Point::new(draw_x, border_y),
+                                Size::new(profile_width, 1.0),
+                                palette.success.strong.color.scale_alpha(0.45),
+                            );
+                        }
+                    }
+                }
+
+                if self.config.show_value_area {
+                    if let (Some(va_lo), Some(va_hi)) = (profile.va_low, profile.va_high) {
+                        let y_top = ((price_max - va_hi) / tick_units) as f32 * row_h;
+                        let y_bot = ((price_max - va_lo) / tick_units + 1) as f32 * row_h;
+                        frame.fill_rectangle(
+                            Point::new(cursor_x.max(PRICE_LABEL_WIDTH), y_top),
+                            Size::new(profile_width, (y_bot - y_top).max(0.0)),
+                            palette.primary.weak.color.scale_alpha(0.07),
+                        );
+                    }
+                }
+
+                for period in &profile.periods {
+                    let col_x = cursor_x + (period.letter_idx as f32 * LETTER_WIDTH);
+                    if col_x + LETTER_WIDTH < PRICE_LABEL_WIDTH || col_x > bounds.width {
+                        continue;
+                    }
+                    let letter_str = period.letter().to_string();
+                    for &price_units in &period.prices {
+                        let row_from_top = ((price_max - price_units) / tick_units) as f32;
+                        let y = row_from_top * row_h;
+                        if y + row_h < 0.0 || y > bounds.height {
+                            continue;
+                        }
+                        let is_poc =
+                            self.config.show_poc && profile.poc == Some(price_units);
+                        let in_va = self.config.show_value_area
+                            && profile
+                                .va_low
+                                .zip(profile.va_high)
+                                .is_some_and(|(lo, hi)| price_units >= lo && price_units <= hi);
+                        let (bg, fg) = if is_poc {
+                            (palette.danger.base.color.scale_alpha(0.85), palette.danger.base.text)
+                        } else if in_va {
+                            (palette.primary.weak.color.scale_alpha(0.65), palette.primary.weak.text)
+                        } else {
+                            (palette.background.strong.color.scale_alpha(0.70), palette.background.strong.text)
+                        };
+                        frame.fill_rectangle(Point::new(col_x, y), Size::new(LETTER_WIDTH, row_h), bg);
+                        if row_h >= 8.0 {
+                            frame.fill_text(Text {
+                                content: letter_str.clone(),
+                                position: Point::new(col_x + LETTER_WIDTH / 2.0, y + row_h / 2.0),
+                                size: TEXT_SIZE,
+                                font: style::AZERET_MONO,
+                                color: fg,
+                                align_x: Alignment::Center.into(),
+                                align_y: Alignment::Center.into(),
+                                ..Default::default()
+                            });
+                        }
+                    }
+                }
+
+                if self.config.show_poc {
+                    if let Some(poc) = profile.poc {
+                        let y = ((price_max - poc) / tick_units) as f32 * row_h + row_h / 2.0;
+                        frame.fill_rectangle(
+                            Point::new(cursor_x.max(PRICE_LABEL_WIDTH), y - 0.5),
+                            Size::new(profile_width, 1.0),
+                            palette.danger.strong.color,
+                        );
+                    }
+                }
+
+                cursor_x += profile_width + SESSION_GAP;
+            }
+
+            let label_step = {
+                let ideal = (bounds.height / 20.0) as i64;
+                if ideal <= 0 { 1 } else { (price_levels as i64 / ideal).max(1) }
+            };
+            let mut label_tick = price_min;
+            while label_tick <= price_max {
+                let row_from_top = (price_max - label_tick) / tick_units;
+                let y = row_from_top as f32 * row_h + row_h / 2.0;
+                if y >= 0.0 && y <= bounds.height {
+                    frame.fill_text(Text {
+                        content: Price::from_units(label_tick)
+                            .to_string(self.ticker_info.min_ticksize),
+                        position: Point::new(PRICE_LABEL_WIDTH - 4.0, y),
+                        size: TEXT_SIZE,
+                        font: style::AZERET_MONO,
+                        color: palette.background.base.text,
+                        align_x: Alignment::End.into(),
+                        align_y: Alignment::Center.into(),
+                        ..Default::default()
+                    });
+                }
+                label_tick += label_step * tick_units;
+            }
+        });
+        vec![content]
+    }
+
+    fn mouse_interaction(
+        &self,
+        _state: &Self::State,
+        _bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        mouse::Interaction::default()
+    }
+}


### PR DESCRIPTION
- data/src/panel/tpo.rs: TpoData, TpoProfile, TpoPeriod, Config with POC, Value Area (70%), and Initial Balance analytics
- src/screen/dashboard/panel/tpo.rs: canvas renderer with letter blocks, color-coded POC/VA/IB, Y-axis price labels, horizontal scroll via mouse wheel
- data/src/layout/pane.rs: Pane::TpoPanel variant, ContentKind::TpoPanel, VisualConfig::Tpo, PaneSetup integration
- src/screen/dashboard/pane.rs + dashboard.rs: TpoPanel wired to M30 kline stream; live and historical kline feeds connected

